### PR TITLE
New --wget/--no-wget and --curl/--no-curl options

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -42,6 +42,8 @@ sub new {
         prompt => undef,
         configure_timeout => 60,
         try_lwp => 1,
+        try_wget => 1,
+        try_curl => 1,
         uninstall_shadows => 1,
         skip_installed => 1,
         @_,
@@ -88,6 +90,8 @@ sub parse_options {
         'self-upgrade' => sub { $self->{cmd} = 'install'; $self->{skip_installed} = 1; push @ARGV, 'App::cpanminus' },
         'uninst-shadows!'  => \$self->{uninstall_shadows},
         'lwp!'    => \$self->{try_lwp},
+        'wget!'   => \$self->{try_wget},
+        'curl!'   => \$self->{try_curl},
     );
 
     $self->{argv} = \@ARGV;
@@ -1205,7 +1209,7 @@ sub init_tools {
             return $res->header('Location') if $res->is_redirect;
             return;
         };
-    } elsif (my $wget = $self->which('wget')) {
+    } elsif ($self->{try_wget} and my $wget = $self->which('wget')) {
         $self->chat("You have $wget\n");
         $self->{_backends}{get} = sub {
             my($self, $uri) = @_;
@@ -1229,7 +1233,7 @@ sub init_tools {
             }
             return;
         };
-    } elsif (my $curl = $self->which('curl')) {
+    } elsif ($self->{try_curl} and my $curl = $self->which('curl')) {
         $self->chat("You have $curl\n");
         $self->{_backends}{get} = sub {
             my($self, $uri) = @_;

--- a/script/cpanm.PL
+++ b/script/cpanm.PL
@@ -208,6 +208,21 @@ Uses L<LWP> module to download stuff over HTTP. Defaults to true, and
 you can say C<--no-lwp> to disable using LWP, when you want to upgrade
 LWP from CPAN on some broken perl systems.
 
+=item --wget
+
+Uses GNU Wget (if available) to download stuff. Defaults to true, and
+you can say C<--no-wget> to disable using Wget (versions of Wget older
+than 1.9 don't support the C<--retry-connrefused> option used by cpanm).
+
+=item --curl
+
+Uses cURL (if available) to download stuff. Defaults to true, and
+you can say C<--no-curl> to disable using cURL.
+
+Normally with C<--lwp>, C<--wget> and C<--curl> options set to true
+(which is the default) cpanm tries L<LWP>, Wget, cURL and L<HTTP::Lite>
+(in that order) and uses the first one available.
+
 =back
 
 =head1 SEE ALSO


### PR DESCRIPTION
Hi,
I've noticed that cpanm didn't work on a machine with an old version of wget that didn't support --retry-connrefused option used by cpanm and I've added a --no-wget option (and --no-curl for completeness) so anyone with older wget could run:
    curl -L http://cpanmin.us | perl - --no-wget --self-upgrade
to bootstrap cpanminus using curl.
By the way, I admire the simplicity of your software. It's a rare thing these days to find Perl modules that don't try to pull half of CPAN and yet they do everything they need. Also, I'm a big fan of PSGI. I've written articles on Wikipedia about PSGI and Plack.
Thanks,
Rafał Pocztarski.
