### PR TITLE
Automatically track local::lib installs via git

### DIFF
--- a/cpanm
+++ b/cpanm
@@ -379,6 +379,7 @@ $fatpacked{"App/cpanminus/script.pm"} = <<'APP_CPANMINUS_SCRIPT';
           'perl=s'    => \$self->{perl},
           'l|local-lib=s' => sub { $self->{local_lib} = $self->maybe_abs($_[1]) },
           'L|local-lib-contained=s' => sub { $self->{local_lib} = $self->maybe_abs($_[1]); $self->{self_contained} = 1 },
+          'g|use-git' => \$self->{use_git},
           'mirror=s@' => $self->{mirrors},
           'mirror-only!' => \$self->{mirror_only},
           'prompt!'   => \$self->{prompt},
@@ -425,6 +426,13 @@ $fatpacked{"App/cpanminus/script.pm"} = <<'APP_CPANMINUS_SCRIPT';
   
       $self->configure_mirrors;
   
+      my $prev_branch;
+      if ($self->{use_git})
+      {
+        $prev_branch = `git name-rev --name-only HEAD`;
+        chomp $prev_branch;
+      }
+  
       my @fail;
       for my $module (@{$self->{argv}}) {
           if ($module =~ s/\.pm$//i) {
@@ -437,6 +445,14 @@ $fatpacked{"App/cpanminus/script.pm"} = <<'APP_CPANMINUS_SCRIPT';
   
       if ($self->{base} && $self->{auto_cleanup}) {
           $self->cleanup_workdirs;
+      if ($self->{use_git})
+      {
+        if (@fail)
+        {
+          $self->run(["git", "checkout", "-q", $prev_branch]);
+        }
+  
+        $self->run(["git", "branch", "-d", (keys %{$self->{git_branches}})]);
       }
   
       return !@fail;
@@ -757,6 +773,23 @@ $fatpacked{"App/cpanminus/script.pm"} = <<'APP_CPANMINUS_SCRIPT';
               $self->{search_inc} = [ @inc ];
           }
           $self->_import_local_lib($base);
+          if ($self->{use_git})
+          {
+            $ENV{GIT_DIR} = File::Spec->canonpath("$base/.git");
+            $ENV{GIT_WORK_TREE} = File::Spec->canonpath("$base");
+            if (! -d "$base/.git")
+            {
+              $self->run(["git", "init", "-q"]);
+              $self->run(["git", "commit", "-q", "--allow-empty", "-m", "Inital Commit"]);
+            }
+          }
+          $self->{use_git} = -d "$base/.git";
+          if ($self->{use_git})
+          {
+            $ENV{GIT_DIR} = File::Spec->canonpath("$base/.git");
+            $ENV{GIT_WORK_TREE} = File::Spec->canonpath("$base");
+            $self->{git_branches} = {};
+          }
       }
   
       $self->bootstrap_local_lib_deps;
@@ -1370,6 +1403,13 @@ $fatpacked{"App/cpanminus/script.pm"} = <<'APP_CPANMINUS_SCRIPT';
   sub build_stuff {
       my($self, $stuff, $dist, $depth) = @_;
   
+      my $prev_branch;
+      if ($self->{use_git})
+      {
+        $prev_branch = `git name-rev --name-only HEAD`;
+        chomp $prev_branch;
+      }
+  
       my @config_deps;
       if (!%{$dist->{meta} || {}} && -e 'META.yml') {
           $self->chat("Checking configure dependencies from META.yml\n");
@@ -1404,6 +1444,25 @@ $fatpacked{"App/cpanminus/script.pm"} = <<'APP_CPANMINUS_SCRIPT';
           return 1;
       }
   
+      if ($self->{use_git})
+      {
+        my $cwd = Cwd::cwd;
+        $self->chdir($self->{local_lib});
+  
+        my $child_branch = `git name-rev --name-only HEAD`;
+        chomp $child_branch;
+  
+        $self->run(["git", "branch", "-f", $dist->{distvname}, $prev_branch]);
+        $self->run(["git", "checkout", "-q", $dist->{distvname}]);
+        $self->{git_branches}->{$dist->{distvname}} = 1;
+  
+        if ($child_branch ne $prev_branch)
+        {
+          $self->run(["git", "merge", "--no-ff", "--no-summary", $child_branch]);
+        }
+        $self->chdir($cwd);
+      }
+  
       my $installed;
       if ($configure_state->{use_module_build} && -e 'Build' && -f _) {
           $self->diag_progress("Building " . ($self->{notest} ? "" : "and testing ") . $distname);
@@ -1428,10 +1487,33 @@ $fatpacked{"App/cpanminus/script.pm"} = <<'APP_CPANMINUS_SCRIPT';
           return;
       }
   
+      #if (rand > 0.8) { return };
+  
       if ($installed) {
           my $local   = $self->{local_versions}{$dist->{module} || ''};
           my $version = $dist->{module_version} || $dist->{meta}{version} || $dist->{version};
           my $reinstall = $local && ($local eq $version);
+  
+          if ($self->{use_git})
+          {
+  
+            $self->chdir($self->{local_lib});
+  
+            $self->run(["git", "add", "$self->{local_lib}"]);
+            $self->run(["git", "commit", "-q", "-m", "Install of '$dist->{module}' v$dist->{module_version}"]);
+  
+            if ($depth == 0)
+            {
+              $self->run(["git", "tag", "-f", $dist->{distvname}]);
+  
+              # Fully merge the previous branch
+              $self->run(["git", "symbolic-ref", "HEAD", "refs/heads/".$prev_branch]);
+              $self->run(["git", "merge", $dist->{distvname}]);
+              $self->run(["git", "branch", "-d", $dist->{distvname}]);
+            }
+  
+            $self->chdir($self->{base});
+          }
   
           my $how = $reinstall ? "reinstalled $distname"
                   : $local     ? "installed $distname (upgraded from $local)"


### PR DESCRIPTION
I wrote this about 6 months ago to track with git all of the installed dependencies for a new project I was working on. We used a locally built perl with nothing but core installed and local::lib to hold all the application's dependencies.  This also showed us all of the packages that we had to install, as well as all the dependencies, install dates and versions of everything.

There are no tests with this request, but if this is a feature you want to integrate, I'd be glad to write some and do any cleanup you need.
