### PR TITLE
Shuffle dependencies list before installing them

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1137,7 +1137,7 @@ sub install_deps {
     }
 
     my @fail;
-    for my $mod (@install) {
+    for my $mod (_shuffle(@install)) {
         $self->install_module($mod, $depth + 1)
             or push @fail, $mod;
     }
@@ -1786,6 +1786,14 @@ sub parse_meta {
 sub parse_meta_string {
     my($self, $yaml) = @_;
     return eval { (Parse::CPAN::Meta::Load($yaml))[0] } || undef;
+}
+
+sub _shuffle {
+    my @result;
+
+    push @result, splice(@_, int(rand($#_)), 1) while @_;
+
+    return @result;
 }
 
 1;


### PR DESCRIPTION
When installing a new perl like the recent 5.14.1 using perlbrew, I needed to re-install all my usual modules. I have a Task::\* for that, but it totals a bit over 400 modules, including dependencies of dependencies.

To make this process faster, I wanted to start several cpanm's tasks in parallel, each using `cpanm --installdeps .`.

With a vanilla `cpanm` this parallelism is not possible because it will always install the same modules in the same sequence on all my parallel runs.

What this patch introduces is a small shuffle in the dependencies list. Each task starts from a different dependency list now, and even though they will try to install the same modules eventually, its unlikely that this will happen at the same time, and so, they will skip over already installed deps.

A "perfect" solution would be to make cpanm truly parallel, managing a configurable pool of workers that did the installing, but that would make cpanm much more complex. This change is much much simpler, and allows us to improve the parallelism of a big cpan install.
