### PR TITLE
chdir to original working directory before each installing module

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -156,6 +156,8 @@ sub doit {
 
     $self->configure_mirrors;
 
+    my $cwd = Cwd::cwd;
+
     my @fail;
     for my $module (@{$self->{argv}}) {
         if ($module =~ s/\.pm$//i) {
@@ -173,6 +175,7 @@ sub doit {
             }
         }
 
+        $self->chdir($cwd);
         $self->install_module($module, 0, $version)
             or push @fail, $module;
     }


### PR DESCRIPTION
When working with local module, cpanminus chdirs to its directory and does not return to original cwd.

So working on several local modules fails after first one:

```
    % cpanm --installdeps ./local/a ./local/b
    --> Working on ./local/a
    Configuring local-a-0.00 ... OK
    <== Installed dependencies for ./local/a. Finishing.
    ! Finding ./local/b on cpanmetadb failed.
    ! Finding ./local/b on search.cpan.org failed.
    ! Finding ./local/b () on mirror http://search.cpan.org/CPAN failed.
    ! Couldn't find module or a distribution ./local/b ()
```
