### PR TITLE
Set umask to 022 to make --sudo work on NFS homes

### DIFF
--- a/cpanm
+++ b/cpanm
@@ -10921,6 +10921,8 @@ use App::cpanminus::script;
 unless (caller) {
     my $app = App::cpanminus::script->new;
     $app->parse_options(@ARGV);
+    # Make sure directories are o+rx so that --sudo works.
+    umask(0022);
     $app->doit or exit(1);
 }
 

--- a/script/cpanm.PL
+++ b/script/cpanm.PL
@@ -20,6 +20,8 @@ use App::cpanminus::script;
 unless (caller) {
     my $app = App::cpanminus::script->new;
     $app->parse_options(@ARGV);
+    # Make sure directories are o+rx so that --sudo works.
+    umask(0022);
     $app->doit or exit(1);
 }
 


### PR DESCRIPTION
When ~ is on an NFS export with root squashing, using sudo will be equivalent
to running as the user 'nobody'. If the umask is 027 when starting cpanm, the
created ~/.cpanm (and subdirectories) will not have the 'r' and 'x' bits set
for 'other'. When cpanm tries to use sudo make install, this will fail with the
error message 'Permission denied'.

Since the directory normally is o+rx (when umask is 022), this change does not
introduce new security problems. It just ensures the environment is as we
expect it :).
