### PR TITLE
Document the '--skip-installed' option

### DIFF
--- a/script/cpanm.PL
+++ b/script/cpanm.PL
@@ -303,6 +303,14 @@ B<EXPERIMENTAL>: Specifies whether to cascade search when you specify
 multiple mirrors and a mirror has a lower version of the module than
 requested. Defaults to false.
 
+=item --skip-installed
+
+Specifies whether a module given in the command line is skipped if its latest
+version is already installed. Defaults to true.
+
+B<NOTE>: The C<PERL5LIB> environment variable have to be correctly set for this
+to work with modules installed using L<local::lib>.
+
 =item --skip-satisfied
 
 B<EXPERIMENTAL>: Specifies whether a module (and version) given in the


### PR DESCRIPTION
This option is mentioned by `--skip-satisfied` but doesn't appear to be documented anywhere in the manpage. I've also added a note about `PERL5LIB` that may help solve some confusion about how it works (see e.g. [#649834](http://bugs.debian.org/649834)).

In the same bug report was also asked whether cpanm could set `PERL5LIB` to a default value (e.g. `~/perl5/...`) if it finds that it isn't set. What do you think?

Cheers
