### PR TITLE
resolve '~' in paths when configuring local::lib for the user

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -522,8 +522,8 @@ sub _core_only_inc {
     my($self, $base) = @_;
     require local::lib;
     (
-        local::lib->install_base_perl_path($base),
-        local::lib->install_base_arch_path($base),
+        local::lib->resolve_path(local::lib->install_base_perl_path($base)),
+        local::lib->resolve_path(local::lib->install_base_arch_path($base)),
         @Config{qw(privlibexp archlibexp)},
     );
 }
@@ -559,8 +559,8 @@ sub setup_local_lib {
             $self->{search_inc} = [ @inc ];
         } else {
             $self->{search_inc} = [
-                local::lib->install_base_arch_path($base),
-                local::lib->install_base_perl_path($base),
+                local::lib->resolve_path(local::lib->install_base_arch_path($base)),
+                local::lib->resolve_path(local::lib->install_base_perl_path($base)),
                 @INC,
             ];
         }


### PR DESCRIPTION
"~/perl5" is used as the default local::lib root when configuring
local::lib for the user.  However, the "install_base_" routines don't
resolve tildes ("~") automatically; "resolve_path" must be called on the
result.
