### PR TITLE
Change warning message about no perms to sitelib

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -510,9 +510,10 @@ sub bootstrap_local_lib {
 ! Can't write to $Config{installsitelib} and $Config{installsitebin}: Installing modules to $ENV{HOME}/perl5
 ! To turn off this warning, you have to do one of the following:
 !   - run me as a root or with --sudo option (to install to $Config{installsitelib} and $Config{installsitebin})
-|   - run me with --local-lib option e.g. cpanm --local-lib=~/perl5
-!   - Set PERL_CPANM_OPT="--local-lib=~/perl5" environment variable (in your shell rc file)
-!   - Configure local::lib in your shell to set PERL_MM_OPT etc.
+!   - Configure local::lib your existing local::lib in this shell to set PERL_MM_OPT etc.
+!   - Install local::lib by running the following commands
+!
+!         cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
 !
 DIAG
     sleep 2;


### PR DESCRIPTION
Make it clearer that local::lib will need to be setup properly.

The advice to set just PERL_CPANM_OPT="--local-lib=~/perl5" would end up with deps being installed into this dir correctly but not being in perl's search path so wouldn't be found by modules that depend upon them.
