### PR TITLE
Do not fall back to searching the mirror when a mirror-index has been specified

### DIFF
--- a/cpanm
+++ b/cpanm
@@ -665,7 +665,11 @@ $fatpacked{"App/cpanminus/script.pm"} = <<'APP_CPANMINUS_SCRIPT';
       if ($self->{mirror_index}) {
           $self->chat("Searching $module on mirror index $self->{mirror_index} ...\n");
           my $pkg = $self->search_mirror_index_file($self->{mirror_index}, $module, $version);
-          return $pkg if $pkg;
+          if (not $pkg) {
+             $self->diag_fail("Finding $module ($version) on mirror index $self->{mirror_index} failed.");
+             return;
+          }
+          return $pkg;
       }
   
       MIRROR: for my $mirror (@{ $self->{mirrors} }) {

--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -353,7 +353,11 @@ sub search_module {
     if ($self->{mirror_index}) {
         $self->chat("Searching $module on mirror index $self->{mirror_index} ...\n");
         my $pkg = $self->search_mirror_index_file($self->{mirror_index}, $module, $version);
-        return $pkg if $pkg;
+        if (not $pkg) {
+           $self->diag_fail("Finding $module ($version) on mirror index $self->{mirror_index} failed.");
+           return;
+        }
+        return $pkg;
     }
 
     MIRROR: for my $mirror (@{ $self->{mirrors} }) {


### PR DESCRIPTION
I'm using cpanm with Pinto to install packages from a local repository.  The repository can have multiple indexes, so the mirror-index option is a perfect fit.  However, when I specify an explicit mirror-index, I **do not** want it to fall back to the repository's default index.  I would argue that this should be the behavior whenever mirror-index is specified.

But I can imagine that some folks might argue the other way.  So perhaps the fall back behavior could be disabled with a separate switch (it looks like --mirror-index already implies --mirror-only).  Let me know if you would prefer that.
