### PR TITLE
fix quoting in local::lib message

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -516,7 +516,7 @@ sub bootstrap_local_lib {
 !   - Configure local::lib your existing local::lib in this shell to set PERL_MM_OPT etc.
 !   - Install local::lib by running the following commands
 !
-!         cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+!         cpanm --local-lib=~/perl5 local::lib && eval \$(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
 !
 DIAG
     sleep 2;


### PR DESCRIPTION
local::lib message which got added in https://github.com/miyagawa/cpanminus/pull/145 is defective:

```
$ curl -L http://cpanmin.us | perl - App::cpanminus
...
!   - Install local::lib by running the following commands
!
!         cpanm --local-lib=~/perl5 local::lib && eval 1001 1001perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
```

So, this is one-character bugfix :)
