### PR TITLE
 Alter tar options for non-BSD tar to ensure 'f' is last

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1848,17 +1848,17 @@ sub init_tools {
         $self->{_backends}{untar} = sub {
             my($self, $tarfile) = @_;
 
-            my $xf = "xf" . ($self->{verbose} ? 'v' : '');
+            my $xf = ($self->{verbose} ? 'v' : '')."xf";
             my $ar = $tarfile =~ /bz2$/ ? 'j' : 'z';
 
-            my($root, @others) = `$tar tf$ar $tarfile`
+            my($root, @others) = `$tar ${ar}tf $tarfile`
                 or return undef;
 
             chomp $root;
             $root =~ s!^\./!!;
             $root =~ s{^(.+?)/.*$}{$1};
 
-            system "$tar $xf$ar $tarfile";
+            system "$tar $ar$xf $tarfile";
             return $root if -d $root;
 
             $self->diag_fail("Bad archive: $tarfile");


### PR DESCRIPTION
Some older tars treat whatever immediately follows the 'f' option as the
filename, so

  tar xfz $file

is interpreted as a requst to unpack the file 'z' - instead, running

  tar zxf $file

will do the right thing.

This makes cpanm work with the tar on e.g. dd-wrt tomato (where there simply
isn't enough memory for e.g. CPAN to be usable so a working cpanm is
pretty much user's only option)
