### PR TITLE
avoid warning on 5.17.0

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1564,7 +1564,7 @@ sub extract_meta_prereqs {
         $self->chat("Finding PREREQ from Makefile ...\n");
         open my $mf, "Makefile";
         while (<$mf>) {
-            if (/^\#\s+PREREQ_PM => {\s*(.*?)\s*}/) {
+            if (/^\#\s+PREREQ_PM => \{\s*(.*?)\s*\}/) {
                 my @all;
                 my @pairs = split ', ', $1;
                 for (@pairs) {


### PR DESCRIPTION
In 5.17, it is becoming a warning to have free-floating { in regex.

This patch (plus a regen of cpanm, which I have not performed) should silence the only occurrence of the warning.
