### PR TITLE
.meta location w/ INSTALLDIRS=perl

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1458,8 +1458,7 @@ sub save_meta {
 
     return unless $dist->{distvname} && $dist->{source} eq 'cpan';
 
-    my $base = ($ENV{PERL_MM_OPT} || '') =~ /INSTALL_BASE=/
-        ? ($self->install_base($ENV{PERL_MM_OPT}) . "/lib/perl5") : $Config{sitelibexp};
+    my $base = $self->install_target_base();
 
     my $provides = $self->_merge_hashref(
         map Module::Metadata->package_versions_from_directory($_),
@@ -1507,10 +1506,13 @@ sub _merge_hashref {
     return \%hash;
 }
 
-sub install_base {
-    my($self, $mm_opt) = @_;
-    $mm_opt =~ /INSTALL_BASE=(\S+)/ and return $1;
-    die "Your PERL_MM_OPT doesn't contain INSTALL_BASE";
+sub install_target_base {
+    my($self) = @_;
+    my $mm_opt = $ENV{PERL_MM_OPT}  or  return $Config{sitelibexp};
+    $mm_opt =~ /INSTALL_BASE=(\S+)/ and return $1 . "/lib/perl5";
+    $mm_opt =~ /INSTALLDIRS=(perl|site|vendor)/
+        and return $Config{ ( { perl => 'priv' }->{$1} || $1 ) . 'libexp' };
+    return $Config{sitelibexp};
 }
 
 sub safe_eval {


### PR DESCRIPTION
PERL_MM_OPT='INSTALLDIRS=perl' or PERL_MM_OPT='INSTALLDIRS=vendor'
now use $Config{privlibexp} and $Config{vendorlibexp} as the
base for the .meta director path.

An arch specific component $Config{archname} is still added to
the base for .meta (which assumes ${archlibexp} eq "${privlibexp}/${archname})

This patch assumes you're using either INSTALLDIRS or INSTALL_BASE
(it gives priority to INSTALL_BASE, which may be incorrect)

closes #159
