### PR TITLE
Unused code removal

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -199,7 +199,7 @@ sub doit {
             $self->check_libs;
             my($ok, $local) = $self->check_module($module, $version || 0);
             if ($ok) {
-                $self->diag("You have $module (" . ($local || 'undef') . ")\n", 1);
+                $self->diag("You have $module ($local)\n", 1);
                 next;
             }
         }


### PR DESCRIPTION
$self->check_module already stringifies undef to 'undef', so no need to
check for it again on its output.
