### PR TITLE
Fix a bug when using --installdeps and a dependency has a cpanfile

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1286,7 +1286,7 @@ sub build_stuff {
 
     $self->diag_progress("Configuring $target");
 
-    my $configure_state = $self->configure_this($dist);
+    my $configure_state = $self->configure_this($dist, $depth);
 
     $self->diag_ok($configure_state->{configured_ok} ? "OK" : "N/A");
 
@@ -1389,9 +1389,9 @@ DIAG
 }
 
 sub configure_this {
-    my($self, $dist) = @_;
+    my($self, $dist, $depth) = @_;
 
-    if (-e 'cpanfile' && $self->{installdeps}) {
+    if (-e 'cpanfile' && $self->{installdeps} && $depth == 0) {
         require Module::CPANfile;
         $dist->{cpanfile} = eval { Module::CPANfile->load('cpanfile') };
         return {
@@ -1464,10 +1464,10 @@ sub configure_this {
     unless ($state->{configured_ok}) {
         while (1) {
             my $ans = lc $self->prompt("Configuring $dist->{dist} failed.\nYou can s)kip, r)etry, e)xamine build log, or l)ook ?", "s");
-            last                                if $ans eq 's';
-            return $self->configure_this($dist) if $ans eq 'r';
-            $self->show_build_log               if $ans eq 'e';
-            $self->look                         if $ans eq 'l';
+            last                                        if $ans eq 's';
+            return $self->configure_this($dist, $depth) if $ans eq 'r';
+            $self->show_build_log                       if $ans eq 'e';
+            $self->look                                 if $ans eq 'l';
         }
     }
 


### PR DESCRIPTION
Hello,

I observed this bug while working on a `Dist::Zilla` plugin; you can duplicate it like so:

```
mkdir /tmp/cpanm-test
cpanm -L /tmp/cpanm-test --installdeps Dist::Zilla::Plugin::Git
```

After doing this, I get the following output

```
<snip>
--> Working on MooseX::Types::Common::String
Fetching file:///home/rob/minicpan/authors/id/E/ET/ETHER/MooseX-Types-Common-0.001008.tar.gz ... OK
Configuring MooseX-Types-Common-0.001008 ... OK
Building MooseX-Types-Common-0.001008 ... OK
Successfully installed MooseX-Types-Common-0.001008
Building MooseX-AttributeShortcuts-0.017 ... OK
Successfully installed MooseX-AttributeShortcuts-0.017
! Bailing out the installation for Dist-Zilla-Plugin-Git-2.002. Retry with --prompt or --force.
```

   156 distributions installed

Here's the end of build.log:

```
Successfully installed MooseX-AttributeShortcuts-0.017
Installing /tmp/cpanm-test/lib/perl5/x86_64-linux/.meta/MooseX-AttributeShortcuts-0.017/MYMETA.json
Installing /tmp/cpanm-test/lib/perl5/x86_64-linux/.meta/MooseX-AttributeShortcuts-0.017/install.json
Already tried Moose. Skipping.
Already tried File::Find::Rule. Skipping.
Already tried namespace::autoclean. Skipping.
Searching Dist::Zilla::Role::AfterMint on cpanmetadb ...
Already tried Dist-Zilla-4.300028. Skipping.
Searching Dist::Zilla on cpanmetadb ...
Already tried Dist-Zilla-4.300028. Skipping.
Already tried String::Formatter. Skipping.
-> FAIL Bailing out the installation for Dist-Zilla-Plugin-Git-2.002. Retry with --prompt or --force.
156 distributions installed
```

Repeating the cpanm command from above delivers more interesting results on standard out:

```
--> Working on Dist::Zilla::Plugin::Git
Fetching file:///home/rob/minicpan/authors/id/C/CJ/CJM/Dist-Zilla-Plugin-Git-2.002.tar.gz ... OK
Configuring Dist-Zilla-Plugin-Git-2.002 ... OK
==> Found dependencies: Dist::Zilla::Tester, Dist::Zilla::Role::Releaser, Test::DZil, Dist::Zilla::Role::AfterRelease, Dist::Zilla::Role::BeforeRelease, Dist::Zilla::Role::PluginBundle, Dist::Zilla::Role::FilePruner, Dist::Zilla::Role::AfterBuild, Dist::Zilla::Plugin::GatherDir, Dist::Zilla::Role::VersionProvider, Dist::Zilla::Role::AfterMint, Dist::Zilla
--> Working on Dist::Zilla::Tester
Fetching file:///home/rob/minicpan/authors/id/R/RJ/RJBS/Dist-Zilla-4.300028.tar.gz ... OK
Configuring Dist-Zilla-4.300028 ... OK
! The distribution doesn't have a proper Makefile.PL/Build.PL See /home/rob/.cpanm/build.log for details.
! Bailing out the installation for Dist-Zilla-Plugin-Git-2.002. Retry with --prompt or --force.
```

So I took a look at the source, and it turns out that if installdeps is on and the distribution has a cpanfile, `configure_this` bails out early without actually configuring anything.  This is fine for the target distribution, but it confuses cpanm when installing dependencies with cpanfiles.  So I added a depth parameter to `configure_this` and pass in the depth.
