### PR TITLE
Fix zip files to find the root more correclty

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -2008,15 +2008,16 @@ sub init_tools {
             $self->diag_fail("Read of file[$file] failed")
                 if $status != Archive::Zip::AZ_OK();
             my @members = $zip->members();
-            my $root;
             for my $member ( @members ) {
                 my $af = $member->fileName();
                 next if ($af =~ m!^(/|\.\./)!);
-                $root = $af unless $root;
                 $status = $member->extractToFileNamed( $af );
                 $self->diag_fail("Extracting of file[$af] from zipfile[$file failed")
                     if $status != Archive::Zip::AZ_OK();
             }
+
+            my ($root) = $zip->membersMatching( qr<^[^/]+/$> );
+            $root &&= $root->fileName;
             return -d $root ? $root : undef;
         };
     }


### PR DESCRIPTION
If the root doesn't happen to be the first entry in the zip file this fails to pick the correct root.  Instead we just find all folders with no subfolders and pick the first one.
