### PR TITLE
a few cross-platform / windows bugs

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -517,8 +517,11 @@ sub _writable {
 
 sub maybe_abs {
     my($self, $lib) = @_;
-    return $lib if $lib eq '_'; # special case: gh-113
-    $lib =~ /^[~\/]/ ? $lib : File::Spec->canonpath(Cwd::cwd . "/$lib");
+    if ($lib ne '_' # special case: gh-113
+        && !File::Spec->file_name_is_absolute($lib)) {
+        $lib = File::Spec->canonpath(File::Spec->catdir(Cwd::cwd(), $lib));
+    }
+    $lib;
 }
 
 sub bootstrap_local_lib {


### PR DESCRIPTION
While working on a build process for a large Jenkins cluster I stumbled across a few bugs on the Windows build nodes.

With these fixed, everything is working great, even on Windows Server 2012.

Fix 1

> File URIs supplied as CPAN mirrors would not work on Windows because of the way it normalised the    path for use with File::Copy

Fix 2

> maybe_abs was creating bad paths on Windows, which in turn broke a lot of stuff, and most importantly, ended up passing strange installation locations to things
