### PR TITLE
Add Workaround for File::Temp rt#44924

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -221,6 +221,13 @@ sub doit {
     if ($self->{scandeps}) {
         $self->dump_scandeps();
     }
+    # Workaround for older File::Temp's
+    # where creating a tempdir with an implicit $PWD
+    # causes tempdir non-cleanup if $PWD changes
+    # as paths are stored internally without being resolved
+    # absolutely.
+    # https://rt.cpan.org/Public/Bug/Display.html?id=44924
+    $self->chdir($cwd);
 
     return !@fail;
 }


### PR DESCRIPTION
I originally only discovered it in my branch that uses File::Fetch, because File::Fetch internally uses File::Temp with an implicit relative path, but was requested to suggest this as a stand-alone pull req.

Code with absolute paths passed explicitly to File::Temp::tempdir( DIR => ) are not affected.
