### PR TITLE
Permit indexes to have extra fields.

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -319,7 +319,7 @@ sub search_mirror_index_file {
     open my $fh, '<', $file or return;
     my $found;
     while (<$fh>) {
-        if (m!^\Q$module\E\s+([\w\.]+)\s+(.*)!m) {
+        if (m!^\Q$module\E\s+([\w\.]+)\s+(\S*)!m) {
             $found = $self->cpan_module($module, $2, $1);
             last;
         }


### PR DESCRIPTION
CPAN.pm allows the index to contain an addtional "comment"
field.  See note here in the source code:

https://github.com/andk/cpanpm/blob/master/lib/CPAN/Index.pm#L376

I would also like to stuff some extra metadata into an index file using
this comment field.  This change allows cpanm to parse such indexes.
