### PR TITLE
Added a "retry without parallel tests" option.

### DIFF
--- a/cpanm
+++ b/cpanm
@@ -1144,14 +1144,36 @@ $fatpacked{"App/cpanminus/script.pm"} = <<'APP_CPANMINUS_SCRIPT';
       } else {
           $self->diag_fail;
           while (1) {
-              my $ans = lc $self->prompt("Testing $distname failed.\nYou can s)kip, r)etry, f)orce install, e)xamine build log, or l)ook ?", "s");
+              my $ans = lc $self->prompt("Testing $distname failed.\nYou can s)kip, r)etry, o) retry with test parallelism turned off, f)orce install, e)xamine build log, or l)ook ?", "s");
               return                              if $ans eq 's';
               return $self->test($cmd, $distname) if $ans eq 'r';
+              return $self->test_no_parallel($cmd, $distname) if $ans eq 'o';
               return 1                            if $ans eq 'f';
               $self->show_build_log               if $ans eq 'e';
               $self->look                         if $ans eq 'l';
           }
       }
+  }
+  
+  sub test_no_parallel {
+      my $self = shift;
+  
+      #
+      # HARNESS_OPTIONS is used by Test::Harness.
+      # It can contain more options than just "j" (for jobs) so we have to be
+      # careful to keep those options while changing the j option to 1 if it
+      # exists.
+      #
+      local $ENV{HARNESS_OPTIONS} = $ENV{HARNESS_OPTIONS} || "";
+      $ENV{HARNESS_OPTIONS} =~ s{(j\d+)?}{j1};
+  
+      #
+      # TEST_JOBS is used by the perl5 source make, and maybe elsewhere?
+      # Just setting it here in case...
+      #
+      local $ENV{TEST_JOBS} = 1;
+  
+      return $self->test(@_);
   }
   
   sub install {

--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -832,14 +832,36 @@ sub test {
     } else {
         $self->diag_fail;
         while (1) {
-            my $ans = lc $self->prompt("Testing $distname failed.\nYou can s)kip, r)etry, f)orce install, e)xamine build log, or l)ook ?", "s");
+            my $ans = lc $self->prompt("Testing $distname failed.\nYou can s)kip, r)etry, o) retry with test parallelism turned off, f)orce install, e)xamine build log, or l)ook ?", "s");
             return                              if $ans eq 's';
             return $self->test($cmd, $distname) if $ans eq 'r';
+            return $self->test_no_parallel($cmd, $distname) if $ans eq 'o';
             return 1                            if $ans eq 'f';
             $self->show_build_log               if $ans eq 'e';
             $self->look                         if $ans eq 'l';
         }
     }
+}
+
+sub test_no_parallel {
+    my $self = shift;
+
+    #
+    # HARNESS_OPTIONS is used by Test::Harness.
+    # It can contain more options than just "j" (for jobs) so we have to be
+    # careful to keep those options while changing the j option to 1 if it
+    # exists.
+    #
+    local $ENV{HARNESS_OPTIONS} = $ENV{HARNESS_OPTIONS} || "";
+    $ENV{HARNESS_OPTIONS} =~ s{(j\d+)?}{j1};
+
+    #
+    # TEST_JOBS is used by the perl5 source make, and maybe elsewhere?
+    # Just setting it here in case...
+    #
+    local $ENV{TEST_JOBS} = 1;
+
+    return $self->test(@_);
 }
 
 sub install {


### PR DESCRIPTION
When the tests fail, if --prompt was specified, cpanm will prompt you
with a few options for how you want to proceed. This change adds an
additional option:

o) retry with test parallelism turned off

If chosen this mode manipulates the environment and then re-runs the
tests. Test suites being incompatible with parallelism is a common flaw
and this change makes it easier to proceed without resorting to using
the "look" and "force install" options.

---

Here's an example of me using the feature successfully.

alex@yuzu:~/Documents/Git/cpanminus$ perl /home/alex/perl5/perlbrew/perls/perl-5.16.2/bin/cpanm File::NFSLock --reinstall --prompt
--> Working on File::NFSLock
Fetching http://www.cpan.org/authors/id/B/BB/BBB/File-NFSLock-1.21.tar.gz ... OK
Configuring File-NFSLock-1.21 ... OK
Building and testing File-NFSLock-1.21 ... FAIL
Testing File-NFSLock-1.21 failed.
You can s)kip, r)etry, o) retry with test parallelism turned off, f)orce install, e)xamine build log, or l)ook ? [s] r
Testing File-NFSLock-1.21 failed.
You can s)kip, r)etry, o) retry with test parallelism turned off, f)orce install, e)xamine build log, or l)ook ? [s] o
Successfully reinstalled File-NFSLock-1.21
1 distribution installed

Before this my pattern was to use the "look" option, try "make test", try "TEST_HARNESS=j1 make test", and then if that succeeded to use "force install" to install as though the tests passed. It was too manual!

---

I considered using "R" as the answer for this option, but the existing implementation was that the answers were all lower-cased before comparison so that wouldn't have worked, so I went with "o".

Hope you'll consider this for inclusion! Thanks for all your great work on cpanminus :-)
