### PR TITLE
Fixed difference of the $dist->{pathname} from the tarballs URI.

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1387,8 +1387,9 @@ sub resolve_name {
 
     # URL
     if ($module =~ /^(ftp|https?|file):/) {
-        if ($module =~ m!authors/id/!) {
-            return $self->cpan_dist($module, $module);
+        if ($module =~ m!authors/id/(.*)!) {
+            my $dist = $1;
+            return $self->cpan_dist($dist, $module);
         } else {
             return { uris => [ $module ] };
         }


### PR DESCRIPTION
I found `--save-dists` problem, if we want save from tarballs URI are:

``` bash
$ cpanm --save-dists tmp http://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.5021.tar.gz
$ find tmp -name "*tar.gz"
tmp/authors/id/http:/cpan.metacpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.5021.tar.gz
```

Looks like bad saved paths. But I fixed it. Please check it.

Tanks,
