### PR TITLE
Grab deps from cpanfile if there is no META.(yml|json)

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1715,6 +1715,10 @@ sub build_stuff {
         push @config_deps, %{$dist->{meta}{configure_requires} || {}};
     }
 
+    if ( $dist->{source} ne 'cpan' && $dist->{meta}{prereqs}{devel}{requires} ) {
+        push @config_deps, %{$dist->{meta}{prereqs}{devel}{requires} || {}};
+    }
+
     my $target = $dist->{meta}{name} ? "$dist->{meta}{name}-$dist->{meta}{version}" : $dist->{dir};
 
     $self->install_deps_bailout($target, $dist->{dir}, $depth, @config_deps)


### PR DESCRIPTION
When installing module from repository, cpanm grab deps from cpanfile, and install configure_requires.

It makes happy to install modules from git.

ref. #212
