### PR TITLE
Added GitHub and BackPAN to the abstract

### DIFF
--- a/cpanm
+++ b/cpanm
@@ -12192,7 +12192,7 @@ __END__
 
 =head1 NAME
 
-cpanm - get, unpack build and install modules from CPAN
+cpanm - get, unpack build and install modules from CPAN, BackPAN, or GitHub
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
A tiny doc mod, changing the abstract from:

  cpanm - get, unpack build and install modules from CPAN

to

  cpanm - get, unpack build and install modules from CPAN, BackPAN, or GitHub

That's it :-)
