### PR TITLE
chdir out of temp directory

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1802,6 +1802,7 @@ DIAG
         $self->diag("$msg\n", 1);
         $self->{installed_dists}++;
         $self->save_meta($stuff, $dist, $module_name, \@config_deps, \@deps);
+        chdir;
         return 1;
     } else {
         my $what = $self->{test_only} ? "Testing" : "Installing";


### PR DESCRIPTION
When I install from github, my tempdir is not removed because I'm still in it.
