### PR TITLE
Add --self-contained as its own flag.

### DIFF
--- a/cpanm
+++ b/cpanm
@@ -442,6 +442,7 @@ $fatpacked{"App/cpanminus/script.pm"} = <<'APP_CPANMINUS_SCRIPT';
               $self->{self_contained} = 1;
               $self->{pod2man} = undef;
           },
+          'self-contained!' => \$self->{self_contained},
           'mirror=s@' => $self->{mirrors},
           'mirror-only!' => \$self->{mirror_only},
           'mirror-index=s'  => \$self->{mirror_index},
@@ -1012,6 +1013,7 @@ $fatpacked{"App/cpanminus/script.pm"} = <<'APP_CPANMINUS_SCRIPT';
     --prompt                  Prompt when configure/build/test fails
     -l,--local-lib            Specify the install base to install modules
     -L,--local-lib-contained  Specify the install base to install all non-core modules
+    --self-contained          Install all non-core modules, even if they're already installed.
     --auto-cleanup            Number of days that cpanm's work directories expire in. Defaults to 7
   
   Commands:
@@ -12402,10 +12404,9 @@ as well.
 
 =item -L, --local-lib-contained
 
-Same with C<--local-lib> but when examining the dependencies, it
-assumes no non-core modules are installed on the system. It's handy if
-you want to bundle application dependencies in one directory so you
-can distribute to other machines.
+Same with C<--local-lib> but with L<--self-contained> set.  All
+non-core dependencies will be installed even if they're already
+installed.
 
 For instance,
 
@@ -12415,6 +12416,12 @@ would install Plack and all of its non-core dependencies into the
 directory C<extlib>, which can be loaded from your application with:
 
   use local::lib '/path/to/extlib';
+
+=item --self-contained
+
+When examining the dependencies, assume no non-core modules are
+installed on the system. Handy if you want to bundle application
+dependencies in one directory so you can distribute to other machines.
 
 =item --mirror
 

--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -128,6 +128,7 @@ sub parse_options {
             $self->{self_contained} = 1;
             $self->{pod2man} = undef;
         },
+        'self-contained!' => \$self->{self_contained},
         'mirror=s@' => $self->{mirrors},
         'mirror-only!' => \$self->{mirror_only},
         'mirror-index=s'  => \$self->{mirror_index},
@@ -698,6 +699,7 @@ Options:
   --prompt                  Prompt when configure/build/test fails
   -l,--local-lib            Specify the install base to install modules
   -L,--local-lib-contained  Specify the install base to install all non-core modules
+  --self-contained          Install all non-core modules, even if they're already installed.
   --auto-cleanup            Number of days that cpanm's work directories expire in. Defaults to 7
 
 Commands:

--- a/script/cpanm.PL
+++ b/script/cpanm.PL
@@ -175,10 +175,9 @@ as well.
 
 =item -L, --local-lib-contained
 
-Same with C<--local-lib> but when examining the dependencies, it
-assumes no non-core modules are installed on the system. It's handy if
-you want to bundle application dependencies in one directory so you
-can distribute to other machines.
+Same with C<--local-lib> but with L<--self-contained> set.  All
+non-core dependencies will be installed even if they're already
+installed.
 
 For instance,
 
@@ -188,6 +187,12 @@ would install Plack and all of its non-core dependencies into the
 directory C<extlib>, which can be loaded from your application with:
 
   use local::lib '/path/to/extlib';
+
+=item --self-contained
+
+When examining the dependencies, assume no non-core modules are
+installed on the system. Handy if you want to bundle application
+dependencies in one directory so you can distribute to other machines.
 
 =item --mirror
 

--- a/xt/self-containted.t
+++ b/xt/self-containted.t
@@ -1,0 +1,15 @@
+use xt::Run;
+use Test::More;
+
+my $local_lib = "$ENV{PERL_CPANM_HOME}/perl5";
+delete $ENV{$_} for qw(PERL5LIB PERL_MM_OPT MODULEBUILDRC);
+$ENV{PERL5LIB} = 'fatlib';
+
+# Something with some non-core dependencies
+run("--self-contained", "-l", $local_lib, "URI::Find");
+
+ok -e "$local_lib/lib/perl5/URI/Find.pm";
+# Dependencies of URI::Find
+ok -e "$local_lib/lib/perl5/URI.pm";
+
+done_testing;


### PR DESCRIPTION
I'd like to request `--self-contained` as its own option separate from `-L`.  This is handy when building system packages (rpms and such) where you want to install all the dependencies, regardless of if they're installed, but don't want to use local::lib.  In those cases I set destdir via the `MM_OPT` and `MB_OPT` environment variables.

This is a feature I can't easily implement from outside cpanm.
