### PR TITLE
POD Error

### DIFF
--- a/lib/App/cpanminus.pm
+++ b/lib/App/cpanminus.pm
@@ -1,6 +1,8 @@
 package App::cpanminus;
 our $VERSION = "1.6107";
 
+=encoding utf-8
+
 =head1 NAME
 
 App::cpanminus - get, unpack, build and install modules from CPAN


### PR DESCRIPTION
From MetaCPAN:

```
1 POD Error
The following errors were encountered while parsing the POD:

Around line 235:
  Non-ASCII character seen before =encoding in '2007−2011'.
  Assuming UTF-8
```
