### PR TITLE
If you have the latest version module A, `cpanm A~9999` does not count as failure.

### DIFF
--- a/xt/recommends_circular.t
+++ b/xt/recommends_circular.t
@@ -1,0 +1,9 @@
+use strict;
+use xt::Run;
+use Test::More;
+
+run_L '--with-recommends', 'URI';
+like last_build_log, qr/Successfully installed Business-ISBN-\d/;
+unlike last_build_log, qr/Installing the dependencies failed: Module 'URI' is not installed/;
+
+done_testing;


### PR DESCRIPTION
Here is what I have done:

```
% perl -MTest::More -E 'say Test::More->VERSION'
0.98
% cpanm Test::More~9999 && echo OK
Test::More is up to date. (0.98)
OK
```

I expected that the second command `cpanm Test::More~9999 && echo OK` would fail with output like `Found Test::More 0.98 which doesn't satisfy 9999.`
