### PR TITLE
Delay runtime recommendations install

### DIFF
--- a/xt/recommends_circular.t
+++ b/xt/recommends_circular.t
@@ -1,0 +1,9 @@
+use strict;
+use xt::Run;
+use Test::More;
+
+run_L '--with-recommends', 'URI';
+like last_build_log, qr/Successfully installed Business-ISBN-\d/;
+unlike last_build_log, qr/Installing the dependencies failed: Module 'URI' is not installed/;
+
+done_testing;


### PR DESCRIPTION
re: miyagawa/carton#81

LWP recommends LWP::Protocol::https which requires LWP. URI recommends Business::ISBN which requires URI.

It might make sense to install 'runtime' recommendations after install, rather than pre-install?
