### PR TITLE
Turn off recommends by default

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -92,7 +92,7 @@ sub new {
         auto_cleanup => 7, # days
         pod2man => 1,
         installed_dists => 0,
-        install_types => ['requires', 'recommends'],
+        install_types => ['requires'],
         with_develop => 0,
         showdeps => 0,
         scandeps => 0,

--- a/xt/recommends.t
+++ b/xt/recommends.t
@@ -2,7 +2,7 @@ use strict;
 use xt::Run;
 use Test::More;
 
-run_L './testdist/TestDist-Recommend';
+run_L '--with-recommends', './testdist/TestDist-Recommend';
 like last_build_log, qr/Checking if you have Try::Tiny/;
 like last_build_log, qr/Checking if you have CPAN::Test::Dummy::Perl5::Build::Fails/;
 like last_build_log, qr/Checking if you have Test::NoWarnings/;
@@ -10,7 +10,7 @@ unlike last_build_log, qr/Checking if you have Hash::MultiValue/;
 like last_build_log, qr/::Build::Fails failed/;
 like last_build_log, qr/Building .* TestDist-Recommend/;
 
-run_L '--notest', './testdist/TestDist-Recommend';
+run_L '--with-recommends', '--notest', './testdist/TestDist-Recommend';
 unlike last_build_log, qr/Checking if you have Test::NoWarnings/;
 like last_build_log, qr/Successfully installed TestDist-Recommend/;
 
@@ -18,7 +18,7 @@ run_L '--with-suggests', '--without-recommends', './testdist/TestDist-Recommend'
 unlike last_build_log, qr/Checking if you have Try::Tiny/;
 like last_build_log, qr/Checking if you have Hash::MultiValue/;
 
-run_L '--with-develop', './testdist/TestDist-Recommend';
+run_L '--with-recommends', '--with-develop', './testdist/TestDist-Recommend';
 like last_build_log, qr/Checking if you have Hash::MultiValue/;
 like last_build_log, qr/Checking if you have Test::Pod/;
 


### PR DESCRIPTION
For the backward compatiblity, some people might want to enable recommends install by default, for build systems like CI systems, even though the failure to install recommendations won't be reported as a failure.
