### PR TITLE
minor typo fix (s/head1//)

### DIFF
--- a/lib/App/cpanminus.pm
+++ b/lib/App/cpanminus.pm
@@ -1,7 +1,7 @@
 package App::cpanminus;
 our $VERSION = "1.6911";
 
-=head1 encoding utf-8
+=encoding utf8
 
 =head1 NAME
 


### PR DESCRIPTION
Hi there!

I was skimming at the docs and saw that the first entry of the automatic pod menu created by MetaCPAN said simply "encoding utf-8"

https://metacpan.org/module/App::cpanminus

This struck me as odd and, since it's a common idiom to set the encoding prior to the pod itself, I'm assuming it's just a typo and you meant "=encoding utf8". If so, this patch fixes it for you. Otherwise, just ignore it :)

Cheers!
