### PR TITLE
point to the new build.PL location

### DIFF
--- a/script/cpanm.PL
+++ b/script/cpanm.PL
@@ -10,7 +10,7 @@
 #
 # For more details about this program, visit http://search.cpan.org/dist/App-cpanminus
 #
-# DEVELOPERS: Read script/build.PL in the repo how to update this
+# DEVELOPERS: Read maint/build.pl in the repo how to update this
 # __FATPACK__
 use strict;
 use FindBin qw($Bin);                        # For dev -- Auto-removed


### PR DESCRIPTION
script/cpanm.PL mentions a script/build.PL file for developers, which doesn't exist anymore. This changes that reference to maint/build.pl, which is the new name/location of that file - or so I hope ;)
