### PR TITLE
mention App::cpanminus::reporter in the pod

### DIFF
--- a/lib/App/cpanminus.pm
+++ b/lib/App/cpanminus.pm
@@ -184,7 +184,7 @@ tools that are mentioned.
 
 =item *
 
-CPAN testers reporting
+CPAN testers reporting. See L<App::cpanminus::reporter>
 
 =item *
 


### PR DESCRIPTION
Hi Miyagawa!

This small docpatch mentions App::cpanminus::reporter in the pod, where you list external apps that add extra functionality to cpanm itself.
