### PR TITLE
Fix #286

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1966,6 +1966,9 @@ sub install_deps {
     $self->chdir($self->{base});
     $self->chdir($dir) if $dir;
 
+    if ($self->{scandeps}) {
+        return 1; # Don't check if dependencies are installed, since with --scandeps they aren't
+    }
     my @not_ok = $self->unsatisfied_deps(@deps);
     if (@not_ok) {
         return 0, \@not_ok;


### PR DESCRIPTION
- Disable dependency installation checks if run with --scandeps
