### PR TITLE
Options for downloading dists into specified directory (so that dists are reusable)

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -102,6 +102,7 @@ sub new {
         format   => 'tree',
         save_dists => undef,
         cache_dir => undef,
+        trust_cache => 0,
         skip_configure => 0,
         verify => 0,
         report_perl_version => 1,
@@ -204,6 +205,7 @@ sub parse_options {
             $self->{save_dists} = $self->maybe_abs($_[1]);
         },
         'cache-dir=s' => sub { $self->{cache_dir} = $self->maybe_abs($_[1]); },
+        'trust-cache' => \$self->{trust_cache},
         'skip-configure!' => \$self->{skip_configure},
         'dev!'       => \$self->{dev_release},
         'metacpan!'  => \$self->{metacpan},
@@ -1579,6 +1581,9 @@ sub fetch_module {
         my $cancelled;
         my $fetch = sub {
             my $file;
+            if ($self->{trust_cache} && $self->{cache_dir}) {
+                return $name if -e $name;
+            }
             eval {
                 local $SIG{INT} = sub { $cancelled = 1; die "SIGINT\n" };
                 $self->mirror($uri, $name);


### PR DESCRIPTION
Current cpanm downloads dists to cpanm working directory.
The working directory changes on every cpanm invocations, so dist files are not shared between other cpanm sessions, downloaded every time.

This patch contains two new options, '--cache-dir' and '--trust-cache'.
'--cache-dir' option represents dist download directory.
Without '--trust-cache', dist file will be retrieved with If-Modified-Since header (when backend if LWP) if file exists.
With '--trust-cache', dist file will not be fetched if exists (any backends).
