### PR TITLE
HPUX 11.11 does not support -z flag to tar

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -18,8 +18,7 @@ use version ();
 use aliased 'App::cpanminus::Dependency';
 
 use constant WIN32 => $^O eq 'MSWin32';
-use constant SUNOS => $^O eq 'solaris';
-use constant HPUX  => $^O eq 'hpux';
+use constant BAD_TAR => ( WIN32 || $^O eq 'solaris' || $^O eq 'hpux' );
 use constant CAN_SYMLINK => eval { symlink("", ""); 1 };
 
 our $VERSION = $App::cpanminus::VERSION;
@@ -2902,7 +2901,7 @@ sub init_tools {
 
     my $tar = $self->which('tar');
     my $tar_ver;
-    my $maybe_bad_tar = sub { WIN32 || SUNOS || HPUX || (($tar_ver = `$tar --version 2>/dev/null`) =~ /GNU.*1\.13/i) };
+    my $maybe_bad_tar = sub { BAD_TAR || (($tar_ver = `$tar --version 2>/dev/null`) =~ /GNU.*1\.13/i) };
 
     if ($tar && !$maybe_bad_tar->()) {
         chomp $tar_ver;


### PR DESCRIPTION
HPUX 11.11 (and others?) need to use gzip to manage compressed tar (tgz) files, as their version of tar does not support -z.

Not certain if there is anything else that needs to be done from a build perspective (not familiar with fatpack, dz, etc).  There should probably be some more specific platform selection, but I don't have access to newer versions of HP-UX.
