### PR TITLE
documentation should suggest using PERL_MM_USE_DEFAULT instead of AUTOMATED_TESTING

### DIFF
--- a/lib/App/cpanminus.pm
+++ b/lib/App/cpanminus.pm
@@ -160,7 +160,7 @@ Tests that require input from STDIN.
 
 =item *
 
-Tests that might fail when C<AUTOMATED_TESTING> is enabled.
+Build.PL or Makefile.PL that prompts for input when C<PERL_MM_USE_DEFAULT> is enabled.
 
 =item *
 


### PR DESCRIPTION
Had a module that was blocking forever unless AUTOMATED_TESTING was set, took me a while to figure out until I checked the Changes file.  The documentation should reflect the new reality.

Cheers.
