### PR TITLE
Override ~/.cpanm with {PERL_CPANM_HOME}

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -43,6 +43,8 @@ sub agent {
 sub determine_home {
     my $class = shift;
 
+	return $ENV{PERL_CPANM_HOME} if $ENV{PERL_CPANM_HOME};
+
     my $homedir = $ENV{HOME}
       || eval { require File::HomeDir; File::HomeDir->my_home }
       || join('', @ENV{qw(HOMEDRIVE HOMEPATH)}); # Win32


### PR DESCRIPTION
Per the docs, PERL_CPANM_HOME is supposed to override ~/.cpanm. This change tries to effect that.
