### PR TITLE
ignore .pm files PAUSE ignores (such as ones in x?t/)

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -2364,6 +2364,7 @@ sub extract_packages {
 
     my $try = sub {
         my $file = shift;
+        return 0 if $file =~ m!^(?:x?t|inc|local|perl5|fatlib)/!;
         return 1 unless $meta->{no_index};
         return 0 if grep { $file =~ m!^$_/! } @{$meta->{no_index}{directory} || []};
         return 0 if grep { $file eq $_ } @{$meta->{no_index}{file} || []};

--- a/xt/pmfiles_pause_ignores.t
+++ b/xt/pmfiles_pause_ignores.t
@@ -1,0 +1,22 @@
+use strict;
+use Test::More;
+use JSON;
+use Config;
+use xt::Run;
+
+my $local_lib = "$ENV{PERL_CPANM_HOME}/perl5";
+
+run_L '--notest', 'DSKOLL/IO-stringy-2.110.tar.gz';
+
+my $file = "$local_lib/lib/perl5/$Config{archname}/.meta/IO-stringy-2.110/install.json";
+open my $in, "<", $file or die $!;
+
+my $data = JSON::decode_json(join "", <$in>);
+is $data->{name}, "IO::Stringy";
+is $data->{version}, '2.110';
+
+# pmfiles in t/ should be excluded
+ok !$data->{provides}{"Common"};
+ok !$data->{provides}{"ExtUtils::TBone"};
+
+done_testing;


### PR DESCRIPTION
a patch to fix #357. Need more examples with inc/, local/, etc?
