### PR TITLE
specify the minimum perl version in metadata

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,6 +8,8 @@ Git::Commit.allow_dirty = cpanm
 [MetaNoIndex]
 file = lib/App/cpanminus/fatscript.pm
 
+[MinimumPerl]
+
 ; needs Run plugin 0.019
 [Run::BeforeBuild]
 run = %x maint/build.pl


### PR DESCRIPTION
closes #376.

There's also [MinimumPerl::Fast], which uses Compiler::Lexer, but it doesn't seem quite robust enough yet for primetime.

BTW I also had to add this to dist.ini to get a successful build:

```
[Encoding]
encoding = latin1
filename = lib/App/cpanminus/fatscript.pm
```

However the latest release (1.7002) seems to have been built with Dist::Zilla 5, so presumably you've already hit this and fixed it.  I might be patching the wrong branch?
