### PR TITLE
don't find directories when searching for executables

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -2738,11 +2738,15 @@ sub shell_quote {
 
 sub which {
     my($self, $name) = @_;
-    return $name if File::Spec->file_name_is_absolute($name) && -x $name;
+    if (File::Spec->file_name_is_absolute($name)) {
+        if (-x $name && !-d _) {
+            return $name;
+        }
+    }
     my $exe_ext = $Config{_exe};
     for my $dir (File::Spec->path) {
         my $fullpath = File::Spec->catfile($dir, $name);
-        if (-x $fullpath || -x ($fullpath .= $exe_ext)) {
+        if ((-x $fullpath || -x ($fullpath .= $exe_ext)) && -d _) {
             if ($fullpath =~ /\s/) {
                 $fullpath = $self->shell_quote($fullpath);
             }


### PR DESCRIPTION
This was noticed initially as Perl-Toolchain-Gang/Module-Metadata#8.
