### PR TITLE
only assume Module::Build configure prereq if no configure prereqs specified

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -2112,7 +2112,7 @@ sub build_stuff {
 
     # workaround for bad M::B based dists with no configure_requires
     # https://github.com/miyagawa/cpanminus/issues/273
-    if (-e 'Build.PL' && !$self->should_use_mm($dist->{dist})) {
+    if (-e 'Build.PL' && !$self->should_use_mm($dist->{dist}) && !@config_deps) {
         push @config_deps, Dependency->from_versions(
             { 'Module::Build' => '0.36' }, 'configure',
         );


### PR DESCRIPTION
If there are configure prereqs specified, assume they are accurate
instead of always adding Module::Build when a Build.PL exists.
