### PR TITLE
dzil: enforce dependency on DZP::Run 0.019 in dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,8 +8,8 @@ Git::Commit.allow_dirty = cpanm
 [MetaNoIndex]
 file = lib/App/cpanminus/fatscript.pm
 
-; needs Run plugin 0.019
 [Run::BeforeBuild]
+:version = 0.019
 run = %x maint/build.pl
 run = %x maint/copy_bin.pl
 


### PR DESCRIPTION
Dzil allows to require minimum versions of plugins using the special key `:version` in the plugin configuration data.
This patch uses this trick in `dist.ini` for the Dist::Zilla::Plugin::Run 0.019 requirement.
