### PR TITLE
core modules may be installed under 'vendor' paths

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -942,7 +942,7 @@ sub _core_only_inc {
     (
         local::lib->resolve_path(local::lib->install_base_arch_path($base)),
         local::lib->resolve_path(local::lib->install_base_perl_path($base)),
-        (!$self->{exclude_vendor} ? @Config{qw(vendorarch vendorlibexp)} : ()),
+        (!$self->{exclude_vendor} ? grep @Config{qw(vendorarch vendorlibexp)} : ()),
         @Config{qw(archlibexp privlibexp)},
     );
 }
@@ -1984,7 +1984,7 @@ sub loaded_from_perl_lib {
 
     require Config;
     my @dirs = qw(archlibexp privlibexp);
-    if ($self->{self_contained} && ! $self->{exclude_vendor}) {
+    if ($self->{self_contained} && ! $self->{exclude_vendor} && $Config{vendorarch}) {
         unshift @dirs, qw(vendorarch vendorlibexp);
     }
     for my $dir (@dirs) {

--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -942,7 +942,7 @@ sub _core_only_inc {
     (
         local::lib->resolve_path(local::lib->install_base_arch_path($base)),
         local::lib->resolve_path(local::lib->install_base_perl_path($base)),
-        (!$self->{exclude_vendor} ? grep @Config{qw(vendorarch vendorlibexp)} : ()),
+        (!$self->{exclude_vendor} ? grep {$_} @Config{qw(vendorarch vendorlibexp)} : ()),
         @Config{qw(archlibexp privlibexp)},
     );
 }

--- a/script/cpanm.PL
+++ b/script/cpanm.PL
@@ -193,15 +193,23 @@ directory C<extlib>, which can be loaded from your application with:
 
   use local::lib '/path/to/extlib';
 
-Note that this option does B<NOT> reliably work with perl
-installations supplied by operating system vendors that strips
-standard modules from perl, such as RHEL, Fedora and CentOS.
+Note that this option does B<NOT> reliably work with perl installations
+supplied by operating system vendors that strips standard modules from perl,
+such as RHEL, Fedora and CentOS, B<UNLESS> you also install packages supplying
+all the modules that have been stripped.  For these systems you will probably
+want to install the C<perl-core> meta-package which does just that.
 
 =item --self-contained
 
 When examining the dependencies, assume no non-core modules are
 installed on the system. Handy if you want to bundle application
 dependencies in one directory so you can distribute to other machines.
+
+=item --exclude-vendor
+
+Don't include modules installed under the 'vendor' paths when searching for
+core modules when the C<--self-contained> flag is in effect.  This restores
+the behaviour from before version 1.7023
 
 =item --mirror
 

--- a/xt/exclude-vendor.t
+++ b/xt/exclude-vendor.t
@@ -1,0 +1,31 @@
+use xt::Run;
+use Test::More;
+
+# If ExtUtils::MakeMaker is installed under vendor path and not a core path,
+# then --exclude-vendor will fail
+
+use Config;
+use Module::Metadata;
+my $vendor_path = $Config{vendorlibexp};
+my $core_path   = $Config{privlibexp};
+
+my $core_mod = 'ExtUtils::MakeMaker';
+
+my $core_in_vendor = 0;
+if ( Module::Metadata->new_from_module( $core_mod, inc => [$vendor_path] ) ) {
+    $core_in_vendor = 1;
+}
+if ( Module::Metadata->new_from_module( $core_mod, inc => [$core_path] ) ) {
+    $core_in_vendor = 0;
+}
+
+SKIP: {
+    skip 'Core modules not moved to vendor on this system' unless $core_in_vendor;
+
+    # Something with some core dependencies
+    run_L( "--exclude-vendor", "URI::Find" );
+
+    like last_build_log, qr{Installing the dependencies failed: Module 'ExtUtils::MakeMaker'};
+}
+
+done_testing;


### PR DESCRIPTION
This is the case for RedHat family of systems, so allow for it it by default.

Restore old behaviour with --exclude-vendor flag.

Also tweak path ordering to be a bit more consistent -- that is, arch paths are checked before non-arch paths.