### PR TITLE
Respect provides in META before using Parse::PMFile

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 See http://github.com/miyagawa/cpanminus/ for the latest development.
 
 {{$NEXT}}
+   [Improvements]
+      - Respect provides in META file before loading from Parse::PMFile
 
 1.7025  2015-02-07 07:58:21 CET
    [Improvements]

--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -2399,7 +2399,7 @@ sub extract_packages {
 
     my @files = grep { /\.pm(?:\.PL)?$/ && $try->($_) } $self->list_files;
 
-    my $provides = {};
+    my $provides = $meta->{provides} || { };
 
     for my $file (@files) {
         my $parser = Parse::PMFile->new($meta, { UNSAFE => 1, ALLOW_DEV_VERSION => 1 });


### PR DESCRIPTION
Modules which chose to live on the ragged edge and have no package statement,
such as those using Moops, Moo(se)X::Declare, et al. class {} statements,
won't get any package statements or versions parsed by Parse::PMFile.
They might have gone to lengths to get their META.* provides correct, though,
and so respecting it seems sensible.