### PR TITLE
Respect meta provides if it exists and ignore packages.

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -2132,8 +2132,16 @@ sub build_stuff {
     my $configure_state = $self->configure_this($dist, $depth);
     $self->diag_ok($configure_state->{configured_ok} ? "OK" : "N/A");
 
-    $dist->{provides} = $self->extract_packages($dist->{cpanmeta}, ".")
-        if $dist->{cpanmeta} && $dist->{source} eq 'cpan';
+    if ($dist->{cpanmeta} && $dist->{source} eq 'cpan'){
+        # PAUSE ignores gathered packages if meta has a provides, so we only extract it if there isn't one
+        my $meta_provides = $dist->{cpanmeta}{provides} || {};
+        if (%$meta_provides){
+            $dist->{provides} = $meta_provides;
+            }
+        else {
+            $dist->{provides} = $self->extract_provides_from_packages($dist->{cpanmeta}, ".");
+            }
+        }
 
     # install direct 'test' dependencies for --installdeps, even with --notest
     my $root_target = (($self->{installdeps} or $self->{showdeps}) and $depth == 0);
@@ -2383,7 +2391,7 @@ sub list_files {
     }
 }
 
-sub extract_packages {
+sub extract_provides_from_packages {
     my($self, $meta, $dir) = @_;
 
     my $try = sub {
@@ -2399,7 +2407,7 @@ sub extract_packages {
 
     my @files = grep { /\.pm(?:\.PL)?$/ && $try->($_) } $self->list_files;
 
-    my $provides = $meta->{provides} || { };
+    my $provides = { };
 
     for my $file (@files) {
         my $parser = Parse::PMFile->new($meta, { UNSAFE => 1, ALLOW_DEV_VERSION => 1 });


### PR DESCRIPTION
Following discussion on PR 435 ( https://github.com/miyagawa/cpanminus/pull/435 ),
we agreed that it's better to ignore the packages if the META has a provides,
because that's what PAUSE does.

Also renames extract_packages to reflect the action slightly better.