### PR TITLE
keep mirror index file as absolute path

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -177,7 +177,7 @@ sub parse_options {
         'exclude-vendor!' => \$self->{exclude_vendor},
         'mirror=s@' => $self->{mirrors},
         'mirror-only!' => \$self->{mirror_only},
-        'mirror-index=s' => \$self->{mirror_index},
+        'mirror-index=s' => sub { $self->{mirror_index} = $self->maybe_abs($_[1]) },
         'M|from=s' => sub {
             $self->{mirrors}     = [$_[1]];
             $self->{mirror_only} = 1;


### PR DESCRIPTION
When I specified a relative path to --mirror-index option, then cpanm could not find some modules.
Here is what I have done:
```
$ cat index.txt
JSON::XS                             3.01     M/ML/MLEHMANN/JSON-XS-3.01.tar.gz
JSON::PP::Boolean                    1.0      M/ML/MLEHMANN/Types-Serialiser-1.0.tar.gz
Types::Serialiser                    1.0      M/ML/MLEHMANN/Types-Serialiser-1.0.tar.gz
Types::Serialiser::BooleanBase       1.0      M/ML/MLEHMANN/Types-Serialiser-1.0.tar.gz
Types::Serialiser::Error             1.0      M/ML/MLEHMANN/Types-Serialiser-1.0.tar.gz
common::sense                        3.73     M/ML/MLEHMANN/common-sense-3.73.tar.gz

$ cpanm --mirror-index index.txt -Llocal JSON::XS
--> Working on JSON::XS
Fetching http://www.cpan.org/authors/id/M/ML/MLEHMANN/JSON-XS-3.01.tar.gz ... OK
Configuring JSON-XS-3.01 ... OK
==> Found dependencies: common::sense, Types::Serialiser
! Finding common::sense (0) on mirror index index.txt failed.
! Couldn't find module or a distribution common::sense
! Finding Types::Serialiser (0) on mirror index index.txt failed.
! Couldn't find module or a distribution Types::Serialiser
! Installing the dependencies failed: Module 'Types::Serialiser' is not installed, Module 'common::sense' is not installed
! Bailing out the installation for JSON-XS-3.01.
```
If I specified `$PWD/index.txt` instead, it worked fine.

It is nice cpanm keeps the mirror index file as absolute path.
