### PR TITLE
use the direct github URL instead of https://cpanmin.us

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ install, and later upgrade.
 
 You can also use the latest cpanminus to install cpanminus itself:
 
-    curl -L https://cpanmin.us | perl - --sudo App::cpanminus
+    curl -L https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm | perl - --sudo App::cpanminus
 
 This will install `cpanm` to your bin directory like
 `/usr/local/bin` and you'll need the `--sudo` option to write to
@@ -46,7 +46,7 @@ tools like [perlbrew](https://metacpan.org/pod/perlbrew), you don't need the `--
 you're most likely to have a write permission to the perl's library
 path. You can just do:
 
-    curl -L https://cpanmin.us | perl - App::cpanminus
+    curl -L https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm | perl - App::cpanminus
 
 to install the `cpanm` executable to the perl's bin path, like
 `~/perl5/perlbrew/bin/cpanm`.
@@ -56,7 +56,7 @@ to install the `cpanm` executable to the perl's bin path, like
 You can also copy the standalone executable to whatever location you'd like.
 
     cd ~/bin
-    curl -L https://cpanmin.us/ -o cpanm
+    curl -L https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm/ -o cpanm
     chmod +x cpanm
 
 This just works, but be sure to grab the new version manually when you

--- a/cpanm
+++ b/cpanm
@@ -9,7 +9,7 @@
 # you. You might want to run it as a root with sudo if you want to install
 # to places like /usr/local/bin.
 #
-#   % curl -L https://cpanmin.us | perl - App::cpanminus
+#   % curl -L https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm | perl - App::cpanminus
 #
 # If you don't have curl but wget, replace `curl -L` with `wget -O -`.
 

--- a/lib/App/cpanminus.pm
+++ b/lib/App/cpanminus.pm
@@ -38,7 +38,7 @@ install, and later upgrade.
 
 You can also use the latest cpanminus to install cpanminus itself:
 
-    curl -L https://cpanmin.us | perl - --sudo App::cpanminus
+    curl -L https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm | perl - --sudo App::cpanminus
 
 This will install C<cpanm> to your bin directory like
 C</usr/local/bin> and you'll need the C<--sudo> option to write to
@@ -51,7 +51,7 @@ tools like L<perlbrew>, you don't need the C<--sudo> option, since
 you're most likely to have a write permission to the perl's library
 path. You can just do:
 
-    curl -L https://cpanmin.us | perl - App::cpanminus
+    curl -L https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm | perl - App::cpanminus
 
 to install the C<cpanm> executable to the perl's bin path, like
 C<~/perl5/perlbrew/bin/cpanm>.
@@ -61,7 +61,7 @@ C<~/perl5/perlbrew/bin/cpanm>.
 You can also copy the standalone executable to whatever location you'd like.
 
     cd ~/bin
-    curl -L https://cpanmin.us/ -o cpanm
+    curl -L https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm/ -o cpanm
     chmod +x cpanm
 
 This just works, but be sure to grab the new version manually when you

--- a/script/cpanm.PL
+++ b/script/cpanm.PL
@@ -9,7 +9,7 @@
 # you. You might want to run it as a root with sudo if you want to install
 # to places like /usr/local/bin.
 #
-#   % curl -L https://cpanmin.us | perl - App::cpanminus
+#   % curl -L https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm | perl - App::cpanminus
 #
 # If you don't have curl but wget, replace `curl -L` with `wget -O -`.
 


### PR DESCRIPTION
First, thank you so much  for a great tool which helps us to enjoy perl ecosystem.

I read the past discussions on this issue.

https://github.com/miyagawa/cpanminus/pull/441
https://github.com/miyagawa/cpanminus/issues/71

sorry if I missed any other discussions to be read.

`curl -L https://cpanmin.us ` does not work  In the latest version of CentOS7 , even with -k option.

```
$ docker run centos:7.1.1503 curl -L -k -vvv https://cpanmin.us

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* About to connect() to cpanmin.us port 443 (#0)
*   Trying 104.28.28.17...
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Connected to cpanmin.us (104.28.28.17) port 443 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
* NSS error -12286 (SSL_ERROR_NO_CYPHER_OVERLAP)
* Cannot communicate securely with peer: no common encryption algorithm(s).
* Error in TLS handshake, trying SSLv3...
> GET / HTTP/1.1
> User-Agent: curl/7.29.0
> Host: cpanmin.us
> Accept: */*
>
* Connection died, retrying a fresh connect
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Closing connection 0
* Issue another request to this URL: 'https://cpanmin.us'
* About to connect() to cpanmin.us port 443 (#1)
*   Trying 104.28.28.17...
* Connected to cpanmin.us (104.28.28.17) port 443 (#1)
* TLS disabled due to previous handshake failure
* NSS error -12286 (SSL_ERROR_NO_CYPHER_OVERLAP)
* Cannot communicate securely with peer: no common encryption algorithm(s).
* Closing connection 1
curl: (35) Cannot communicate securely with peer: no common encryption algorithm(s).
```

CentOS (or RHEL) or curl may be blamed for this error,
and I know we can work around it  by using the direct URL https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm or  by using rpm package as described in README.

But I think this kind of problem makes perl beginners feel difficulties, So I propose to use the direct URL in the document.

## Pros
* less issues
* kind to perl beginners

## Cons
* longer numbers of characters to type (but I guess most people copy and paste the installation command in the document)
* less pretty

# Another Proposition : https://git.io/cpanm

If you prefer a short URL, How about using https://git.io ? ( https://github.com/blog/985-git-io-github-url-shortener )

I registered one today for this project https://git.io/cpanm by executing this:

```
curl -i http://git.io -F "url=https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm" -F "code=cpanm"
```

And this works fine on CentOS7

```
docker run centos:7.1.1503 curl -v  https://git.io/cpanm
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* About to connect() to git.io port 443 (#0)
*   Trying 50.17.197.193...
* Connected to git.io (50.17.197.193) port 443 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
*   CAfile: /etc/pki/tls/certs/ca-bundle.crt
  CApath: none
* SSL connection using TLS_DHE_RSA_WITH_AES_128_CBC_SHA
* Server certificate:
*       subject: CN=git.io,O="GitHub, Inc.",L=San Francisco,ST=California,C=US
*       start date: Apr 09 00:00:00 2014 GMT
*       expire date: Apr 12 12:00:00 2017 GMT
*       common name: git.io
*       issuer: CN=DigiCert SHA2 High Assurance Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0> GET /cpanm HTTP/1.1
> User-Agent: curl/7.29.0
> Host: git.io
> Accept: */*
>
< HTTP/1.1 302 Found
< Server: Cowboy
< Connection: keep-alive
< Date: Mon, 27 Apr 2015 03:48:23 GMT
< Status: 302 Found
< Content-Type: text/html;charset=utf-8
< Location: https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm
< Content-Length: 0
< X-Xss-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Runtime: 0.002493
< X-Node: 10cbac2c-1808-4bb1-a46c-ac3209df5197
< X-Revision: 07773b075b4450646b285dbdf0ec55f6bff3a278
< Via: 1.1 vegur
<
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
* Connection #0 to host git.io left intact
```