### PR TITLE
When resolving name, try git uri first

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1809,6 +1809,11 @@ sub verify_signature {
 sub resolve_name {
     my($self, $module, $version) = @_;
 
+    # Git
+    if ($module =~ /(?:^git:|\.git(?:@.+)?$)/) {
+        return $self->git_uri($module);
+    }
+
     # URL
     if ($module =~ /^(ftp|https?|file):/) {
         if ($module =~ m!authors/id/(.*)!) {
@@ -1832,11 +1837,6 @@ sub resolve_name {
             source => 'local',
             uris => [ "file://" . Cwd::abs_path($module) ],
         };
-    }
-
-    # Git
-    if ($module =~ /(?:^git:|\.git(?:@.+)?$)/) {
-        return $self->git_uri($module);
     }
 
     # cpan URI

--- a/xt/git_uri.t
+++ b/xt/git_uri.t
@@ -22,5 +22,10 @@ run 'git://github.com/miyagawa/CPAN-Test-Dummy-FromGit.git@nonexistent';
 like last_build_log, qr/Failed to checkout 'nonexistent'/;
 unlike last_build_log, qr/cannot remove path/;
 
+# check http(s) git uri works
+run "https://github.com/miyagawa/CPAN-Test-Dummy-FromGit.git";
+like last_build_log, qr/Cloning/;
+like last_build_log, qr/installed .*-0\.01/;
+
 done_testing;
 


### PR DESCRIPTION
Currently
```
cpanm git://github.com/miyagawa/cpanminus.git
```
works, but
```
cpanm https://github.com/miyagawa/cpanminus.git
```
does not.

It seems that github.com recommends `https`. And some git servers does not support `git` protocol at all.
So I think it is nice cpanm supports http(s) git uri.