### PR TITLE
Update submodules when using a git source

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1902,7 +1902,7 @@ sub git_uri {
     my $dir = File::Temp::tempdir(CLEANUP => 1);
 
     $self->mask_output( diag_progress => "Cloning $uri" );
-    $self->run([ 'git', 'clone', $uri, $dir ]);
+    $self->run([ 'git', 'clone','--recurse-submodules', $uri, $dir ]);
 
     unless (-e "$dir/.git") {
         $self->diag_fail("Failed cloning git repository $uri", 1);
@@ -1917,6 +1917,13 @@ sub git_uri {
             $self->diag_fail("Failed to checkout '$commitish' in git repository $uri\n");
             return;
         }
+        if (-e "$dir/.gitmodules") {
+            unless ($self->run([ 'git', 'submodule','update'])) {
+                $self->diag_fail("Failed to checkout the submoudules in git repository $uri\n");
+                return;
+            }
+       }
+
     }
 
     $self->diag_ok;


### PR DESCRIPTION
This month I got as assignment for the cpan pull request Redis::Fast (https://github.com/shogo82148/Redis-Fast) that drive me to know Minilla.
After reading that projects using Minilla could be installed with cpann form its git repository I tested it with Redis::Fast and noticed that its git repository has submodules and that cpanminus didn't handle it correctly.

This path makes cpanm clone the repository recursively  and when using a specific commit  update use the submodules to the correct version