### PR TITLE
output interesting running flags

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -412,6 +412,16 @@ sub setup_home {
 
     $self->chat("cpanm (App::cpanminus) $VERSION on perl $] built for $Config{archname}\n" .
                 "Work directory is $self->{base}\n");
+                "Work directory is $self->{base}\n" .
+                "Running with: " . join(' ',
+                    grep { exists $self->{$_} && $self->{$_} }
+                    qw(force notest test_only sudo verbose quiet self_contained
+                       exclude_vendor prompt dev reinstall pure_perl
+                       with_develop skip_installed skip_satisfied verify
+                       interactive installdeps
+                    )
+                ) . "\n"
+    );
 }
 
 sub package_index_for {


### PR DESCRIPTION
Hi!

This is a small patch to display the most important cpanm running flags to the output (either STDOUT or build.log), right after the main header. This should fix #495 and help people debug their installations, specially since there are so many different tools relying on potentially different runs of cpanm (e.g. carton).

If everything goes as expected, no one will even see it. But if you're skimming through your build.log output, it's probably because something didn't go as expected, so I think it'd be good to see at least how that run was made by cpanm.

Of course, if you merge this, please feel more than welcome to change the text formatting and what options get logged. I just put the ones I thought would be interesting :)

Thanks again for the incredible work!