### PR TITLE
cpanm detects and does not try to double-install modules that depend on themselves

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -2205,7 +2205,16 @@ sub build_stuff {
     push @{$dist->{want_phases}}, 'develop' if $self->{with_develop} && $depth == 0;
     push @{$dist->{want_phases}}, 'configure' if $self->{with_configure} && $depth == 0;
 
-    my @deps = $self->find_prereqs($dist);
+    my @all_deps = $self->find_prereqs($dist);
+    my @deps = grep { $_->{module} ne $dist->{module} } @all_deps;
+
+    if ( @deps != @all_deps ) {
+        $self->chat(<<DIAG, 1);
+! $dist->{module} specifies itself as a dependency.
+! Omitting it from the list of dependencies.
+DIAG
+    }
+
     my $module_name = $self->find_module_name($configure_state) || $dist->{meta}{name};
     $module_name =~ s/-/::/g;
 

--- a/xt/prereq_cycle.t
+++ b/xt/prereq_cycle.t
@@ -1,0 +1,11 @@
+use xt::Run;
+use Test::More;
+
+my $stdout = run qw(--showdeps Bundle::CPAN);
+
+like last_build_log, qr/! Bundle::CPAN specifies itself as a dependency\./;
+
+# Bundle::CPAN is not shown in the list of dependencies
+unlike $stdout, qr/^Bundle::CPAN$/;
+
+done_testing;


### PR DESCRIPTION
Some modules list themselves as dependencies (looking at you, `Bundle::CPAN`).  In combination with `cpanm`'s tracking of `$self->{seen}{$module}`, this causes `cpanm` to mark such a module as having an unsatisfied dependency -- namely, itself.  This PR implements a fix that filters out a module from the list of its dependencies and issues a warning message to that effect.