### PR TITLE
 Suppress GNU tar warnings about unknown keywords

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -3018,7 +3018,6 @@ sub init_tools {
     my $tar = $self->which('tar');
     my $tar_ver;
     my $maybe_bad_tar = sub { WIN32 || BAD_TAR || (($tar_ver = `$tar --version 2>/dev/null`) =~ /GNU.*1\.13/i) };
-    my $gnu_tar = sub { ($tar_ver = `$tar --version 2>/dev/null`) =~ /\bGNU\b/i };
 
     if ($tar && !$maybe_bad_tar->()) {
         chomp $tar_ver;
@@ -3028,7 +3027,7 @@ sub init_tools {
 
             my $xf = ($self->{verbose} ? 'v' : '')."xf";
             my $ar = $tarfile =~ /bz2$/ ? 'j' : 'z';
-            my $nowarn = $gnu_tar->() ? '--warning=no-unknown-keyword' : ''; # BSD tar does not support --warning=xxx
+            my $nowarn = $tar_ver =~ /\bGNU\b/ ? '--warning=no-unknown-keyword' : ''; # BSD tar does not support --warning=xxx
 
             my($root, @others) = `$tar $nowarn -${ar}tf $tarfile`
                 or return undef;


### PR DESCRIPTION
If an archive is e.g. built on MacOS, usually additional informations are
included. When unpacking this using GNU tar there are messages like:

    tar: Ignoring unknown extended header keyword `SCHILY.ino'
    tar: Ignoring unknown extended header keyword `SCHILY.nlink'
    tar: Ignoring unknown extended header keyword `SCHILY.dev'

To prevent this the option `--warning=no-unknown-keyword` was added if tar
is the GNU version (BSD tar does not support the option).