### PR TITLE
When scanning packages include files like _pm.PL

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -2461,7 +2461,7 @@ sub extract_packages {
 
     require Parse::PMFile;
 
-    my @files = grep { /\.pm(?:\.PL)?$/ && $try->($_) } $self->list_files;
+    my @files = grep { /(?:(\.pm(?:\.PL)?)|(_pm\.PL))$/ && $try->($_) } $self->list_files;
 
     my $provides = { };
 

--- a/xt/provides.t
+++ b/xt/provides.t
@@ -29,5 +29,13 @@ my $local_lib = "$ENV{PERL_CPANM_HOME}/perl5";
     };
 }
 
+{
+    run_L "SAPER/XSLoader-0.22.tar.gz";
+    my $file = "$local_lib/lib/perl5/$Config{archname}/.meta/XSLoader-0.22/install.json";
+
+    my $data = load_json $file;
+    ok exists $data->{provides}{XSLoader};
+}
+
 done_testing;
 


### PR DESCRIPTION
Some distributions use _pm.PL as the suffix for their code. One example is
XSLoader 0.22.

Without this fix, the extract_packages() code would not find this file,
and would not parse it. In the end, a install of XSLoader will not have
a provides meta.

---

It took me quite some time to get here. It started with Carton.

This simple `cpanfile` will not install properly:

    requires "List::MoreUtils";

To reproduce, create a `cpanfile` with just that line and do:

    rm -rf cpanfile.snapshot local ## reset
    carton install
    rm -rf local
    carton install --deployment

The error message is:

    Found XSLoader  which doesn't satisfy 0.22.
    Successfully installed Exporter-Tiny-0.042
    ! Installing the dependencies failed: Installed version (0.17) of XSLoader is not in range '0.22'
    ! Bailing out the installation for List-MoreUtils-0.416.
    ! Installing the dependencies failed: Module 'List::MoreUtils' is not installed
    ! Bailing out the installation for /Users/melo/llll/.
    1 distribution installed
    Installing modules failed

The problem is that, if you look at `cpanfile.snapshot`, the `XSLoader` entry has a bad `provides` section:

      XSLoader-0.22
        pathname: S/SA/SAPER/XSLoader-0.22.tar.gz
        provides:
          XSLoader undef
        requirements:
          ExtUtils::MakeMaker 0
          Test::More 0.47

This will create a `local/cache/modules/02packages.details.txt` index file with `XSLoader` line like this:

    XSLoader                          undef  S/SA/SAPER/XSLoader-0.22.tar.gz

Going back up from the rabbit hole, the problem is that when `cpanm` is installing the `XSLoader` package, it fails to obtain a valid `provides` section.

The reason is that the `.pm` files that `App::cpanminus::script::extract_packages()` scans to obtain this ignore files ending with `_pm.PL`, and `XSLoader` dist uses this suffix.

By changing the filter of `.pm` files to scan to find provides to include them, we fix the issue.