### PR TITLE
Only use URI from mirror where we found the module and not from all m…

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -787,8 +787,13 @@ sub search_module {
             $self->{pkgs}{$uri} = "!!retrieved!!";
         }
 
-        my $pkg = $self->search_mirror_index($mirror, $module, $version);
-        return $pkg if $pkg;
+        {
+            # only use URI from the found mirror
+            local $self->{mirrors} = [$mirror];
+
+            my $pkg = $self->search_mirror_index($mirror, $module, $version);
+            return $pkg if $pkg;
+        }
 
         $self->mask_output( diag_fail => "Finding $module ($version) on mirror $mirror failed." );
     }


### PR DESCRIPTION
…irrors.

When multiple --mirrors are used, cpan_dist() will construct URIs from all
mirrors, regardless or whether this mirror contains the module or not. This can
cause a lot of noise warnings of failing to fetch files from the mirrors,
particularly when darkpan(s) are involved. For example:

    % cpanm --mirror http://darkpan1/ --mirror http://darkpan2/ \
        --mirror http://darkpan3/ --mirror http://cpan/ --mirror-only \
        A-CPAN-Module-1.23.tar.gz
    ! Finding A::CPAN::Module () on mirror http://darkpan1/ failed.
    ! Finding A::CPAN::Module () on mirror http://darkpan2/ failed.
    ! Finding A::CPAN::Module () on mirror http://darkpan3/ failed.
    --> Working on A::CPAN::Module
    Fetching http://darkpan1/authors/id/P/PA/PAUSEID/A-CPAN-Module-1.23.tar.gz ... FAIL
    ! Download http://darkpan1/authors/id/P/PA/PAUSEID/A-CPAN-Module-1.23.tar.gz failed. Retrying ...
    ! Download http://darkpan1/authors/id/P/PA/PAUSEID/A-CPAN-Module-1.23.tar.gz failed. Retrying ...
    ! Download http://darkpan1/authors/id/P/PA/PAUSEID/A-CPAN-Module-1.23.tar.gz failed. Retrying ...
    Fetching http://darkpan2/authors/id/P/PA/PAUSEID/A-CPAN-Module-1.23.tar.gz ... FAIL
    ! Download http://darkpan2/authors/id/P/PA/PAUSEID/A-CPAN-Module-1.23.tar.gz failed. Retrying ...
    ! Download http://darkpan2/authors/id/P/PA/PAUSEID/A-CPAN-Module-1.23.tar.gz failed. Retrying ...
    ! Download http://darkpan2/authors/id/P/PA/PAUSEID/A-CPAN-Module-1.23.tar.gz failed. Retrying ...
    Fetching http://darkpan3/authors/id/P/PA/PAUSEID/A-CPAN-Module-1.23.tar.gz ... FAIL
    ! Download http://darkpan3/authors/id/P/PA/PAUSEID/A-CPAN-Module-1.23.tar.gz failed. Retrying ...
    ! Download http://darkpan3/authors/id/P/PA/PAUSEID/A-CPAN-Module-1.23.tar.gz failed. Retrying ...
    ! Download http://darkpan3/authors/id/P/PA/PAUSEID/A-CPAN-Module-1.23.tar.gz failed. Retrying ...
    Fetching http://cpan/authors/id/P/PA/PAUSEID/A-CPAN-Module-1.23.tar.gz ... OK
    ...

With this small commit, the distribution A-CPAN-Module will only get the
http://cpan/ URL as that is where the associated module is found. So, the noise
is much reduced:

    % cpanm --mirror http://darkpan1/ --mirror http://darkpan2/ \
        --mirror http://darkpan3/ --mirror http://cpan/ --mirror-only \
        A-CPAN-Module-1.23.tar.gz
    ! Finding A::CPAN::Module () on mirror http://darkpan1/ failed.
    ! Finding A::CPAN::Module () on mirror http://darkpan2/ failed.
    ! Finding A::CPAN::Module () on mirror http://darkpan3/ failed.
    --> Working on A::CPAN::Module
    Fetching http://cpan/authors/id/P/PA/PAUSEID/A-CPAN-Module-1.23.tar.gz ... OK
    ...