### PR TITLE
fix xt/build_no_mymeta.t

### DIFF
--- a/xt/build_no_mymeta.t
+++ b/xt/build_no_mymeta.t
@@ -4,11 +4,12 @@ use Test::More;
 
 plan skip_all => "only on 5.10.1" if $] != 5.010001;
 
-run 'Module::Build@0.340201';
+run 'http://backpan.perl.org/authors/id/D/DA/DAGOLDEN/Module-Build-0.340201.tar.gz';
 like last_build_log, qr/installed Module-Build/;
 
-run 'Hook::LexWrap';
+my ($stdout, $stderr, $exit) = run 'Hook::LexWrap@0.24';
 unlike last_build_log, qr/Failed to upconvert metadata/;
+unlike $stderr, qr/Failed to upconvert metadata/;
 
 done_testing;
 


### PR DESCRIPTION
Hopefully fixes the test failures of #520 and #522.

xt/build_no_mymeta.t was added in https://github.com/miyagawa/cpanminus/commit/cc9456f7725fb93d8ffc314e6b36b31926aadc49 
to ensure that cpanm does not die with `Failed to upconvert metadata`
when calling extract_prereqs method.

There are a few issues:
* xt/build_no_mymeta.t first installs Module::Build 0.340201.    
On the other hand, Module::Build 0.340201 is UNAUTHORIZED (https://metacpan.org/release/DAGOLDEN/Module-Build-0.340201).
So it shoud not be resolved via `Module::Build@0.340201` (but it accidentally can be resolved by MetaCPAN v0 API)
* The latest Hook::LexWrap may use Module::Build::Tiny, not Module::Build. https://metacpan.org/source/ETHER/Hook-LexWrap-0.25/Build.PL

This PR tries to resolve these issues.