### PR TITLE
Fall back to skeleton META if META.yml parse fails

### DIFF
--- a/lib/Menlo/CLI/Compat.pm
+++ b/lib/Menlo/CLI/Compat.pm
@@ -1912,7 +1912,8 @@ sub build_stuff {
     if ($meta_file) {
         $self->chat("Checking configure dependencies from $meta_file\n");
         $dist->{cpanmeta} = eval { CPAN::Meta->load_file($meta_file) };
-    } elsif ($dist->{dist} && $dist->{version}) {
+    }
+    if (!$dist->{cpanmeta} && $dist->{dist} && $dist->{version}) {
         $self->chat("META.yml/json not found. Creating skeleton for it.\n");
         $dist->{cpanmeta} = CPAN::Meta->new({ name => $dist->{dist}, version => $dist->{version} });
     }


### PR DESCRIPTION
Some anti-social dists (e.g. AnyEvent::AIO) use JSON in their META.yml file, which is not able to be parsed by YAML::Tiny. This results in an empty `provides` hash, and confuses carmel.

This change falls back to the behavior of a non-existent META file if CPAN::Meta is unable to parse the existing META file. Which means the dist files are searched to populate the `provides` hash.