### PR TITLE
If paths of commands contain spaces, quote them

### DIFF
--- a/lib/Menlo/CLI/Compat.pm
+++ b/lib/Menlo/CLI/Compat.pm
@@ -11,7 +11,6 @@ use File::Path ();
 use File::Spec ();
 use File::Copy ();
 use File::Temp ();
-use File::Which qw(which);
 use Getopt::Long ();
 use Symbol ();
 use version ();
@@ -279,7 +278,7 @@ sub setup_verify {
     my $self = shift;
 
     my $has_modules = eval { require Module::Signature; require Digest::SHA; 1 };
-    $self->{cpansign} = which('cpansign');
+    $self->{cpansign} = Menlo::Util::which('cpansign');
 
     unless ($has_modules && $self->{cpansign}) {
         warn "WARNING: Module::Signature and Digest::SHA is required for distribution verifications.\n";
@@ -1131,7 +1130,7 @@ sub show_build_log {
     while (@pagers) {
         $pager = shift @pagers;
         next unless $pager;
-        $pager = which($pager);
+        $pager = Menlo::Util::which($pager);
         next unless $pager;
         last;
     }
@@ -2692,13 +2691,13 @@ sub init_tools {
 
     return if $self->{initialized}++;
 
-    if ($self->{make} = which($Config{make})) {
+    if ($self->{make} = Menlo::Util::which($Config{make})) {
         $self->chat("You have make $self->{make}\n");
     }
 
     $self->{http} = $self->configure_http;
 
-    my $tar = which('tar');
+    my $tar = Menlo::Util::which('tar');
     my $tar_ver;
     my $maybe_bad_tar = sub { WIN32 || BAD_TAR || (($tar_ver = `$tar --version 2>/dev/null`) =~ /GNU.*1\.13/i) };
 
@@ -2733,8 +2732,8 @@ sub init_tools {
             return undef;
         }
     } elsif (    $tar
-             and my $gzip = which('gzip')
-             and my $bzip2 = which('bzip2')) {
+             and my $gzip = Menlo::Util::which('gzip')
+             and my $bzip2 = Menlo::Util::which('bzip2')) {
         $self->chat("You have $tar, $gzip and $bzip2\n");
         $self->{_backends}{untar} = sub {
             my($self, $tarfile) = @_;
@@ -2788,7 +2787,7 @@ sub init_tools {
         };
     }
 
-    if (my $unzip = which('unzip')) {
+    if (my $unzip = Menlo::Util::which('unzip')) {
         $self->chat("You have $unzip\n");
         $self->{_backends}{unzip} = sub {
             my($self, $zipfile) = @_;

--- a/lib/Menlo/Util.pm
+++ b/lib/Menlo/Util.pm
@@ -1,6 +1,7 @@
 package Menlo::Util;
 use strict;
 
+use File::Which ();
 use Exporter;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(WIN32);
@@ -13,6 +14,13 @@ if (WIN32) {
 } else {
     require String::ShellQuote;
     *shell_quote = \&String::ShellQuote::shell_quote_best_effort;
+}
+
+sub which {
+    my $name = shift;
+    my $path = File::Which::which($name);
+    return unless $path;
+    $path =~ /\s/ ? shell_quote($path) : $path;
 }
 
 1;


### PR DESCRIPTION
Address #545 

Use our own which() instead of File::Which::which() directly;
if paths of commands contain spaces, quote them.