### PR TITLE
Quote cpansign/pager/tar/gzip/bzip2/unzip if it contains spaces

### DIFF
--- a/lib/Menlo/CLI/Compat.pm
+++ b/lib/Menlo/CLI/Compat.pm
@@ -11,6 +11,7 @@ use File::Path ();
 use File::Spec ();
 use File::Copy ();
 use File::Temp ();
+use File::Which qw(which);
 use Getopt::Long ();
 use Symbol ();
 use version ();
@@ -278,7 +279,7 @@ sub setup_verify {
     my $self = shift;
 
     my $has_modules = eval { require Module::Signature; require Digest::SHA; 1 };
-    $self->{cpansign} = Menlo::Util::which('cpansign', 1);
+    $self->{cpansign} = which('cpansign');
 
     unless ($has_modules && $self->{cpansign}) {
         warn "WARNING: Module::Signature and Digest::SHA is required for distribution verifications.\n";
@@ -1130,7 +1131,7 @@ sub show_build_log {
     while (@pagers) {
         $pager = shift @pagers;
         next unless $pager;
-        $pager = Menlo::Util::which($pager, 1);
+        $pager = which($pager);
         next unless $pager;
         last;
     }
@@ -2691,13 +2692,13 @@ sub init_tools {
 
     return if $self->{initialized}++;
 
-    if ($self->{make} = Menlo::Util::which($Config{make})) {
+    if ($self->{make} = which($Config{make})) {
         $self->chat("You have make $self->{make}\n");
     }
 
     $self->{http} = $self->configure_http;
 
-    my $tar = Menlo::Util::which('tar', 1);
+    my $tar = which('tar');
     my $tar_ver;
     my $maybe_bad_tar = sub { WIN32 || BAD_TAR || (($tar_ver = `$tar --version 2>/dev/null`) =~ /GNU.*1\.13/i) };
 
@@ -2732,8 +2733,8 @@ sub init_tools {
             return undef;
         }
     } elsif (    $tar
-             and my $gzip = Menlo::Util::which('gzip', 1)
-             and my $bzip2 = Menlo::Util::which('bzip2', 1)) {
+             and my $gzip = which('gzip')
+             and my $bzip2 = which('bzip2')) {
         $self->chat("You have $tar, $gzip and $bzip2\n");
         $self->{_backends}{untar} = sub {
             my($self, $tarfile) = @_;
@@ -2787,7 +2788,7 @@ sub init_tools {
         };
     }
 
-    if (my $unzip = Menlo::Util::which('unzip', 1)) {
+    if (my $unzip = which('unzip')) {
         $self->chat("You have $unzip\n");
         $self->{_backends}{unzip} = sub {
             my($self, $zipfile) = @_;

--- a/lib/Menlo/CLI/Compat.pm
+++ b/lib/Menlo/CLI/Compat.pm
@@ -1113,7 +1113,7 @@ sub look {
     if ($shell) {
         my $cwd = Cwd::cwd;
         $self->diag("Entering $cwd with $shell\n");
-        safe_system([$shell]);
+        system $shell;
     } else {
         $self->diag_fail("You don't seem to have a SHELL :/");
     }

--- a/lib/Menlo/CLI/Compat.pm
+++ b/lib/Menlo/CLI/Compat.pm
@@ -11,7 +11,6 @@ use File::Path ();
 use File::Spec ();
 use File::Copy ();
 use File::Temp ();
-use File::Which qw(which);
 use Getopt::Long ();
 use Symbol ();
 use version ();
@@ -279,7 +278,7 @@ sub setup_verify {
     my $self = shift;
 
     my $has_modules = eval { require Module::Signature; require Digest::SHA; 1 };
-    $self->{cpansign} = which('cpansign');
+    $self->{cpansign} = Menlo::Util::which('cpansign', 1);
 
     unless ($has_modules && $self->{cpansign}) {
         warn "WARNING: Module::Signature and Digest::SHA is required for distribution verifications.\n";
@@ -1131,7 +1130,7 @@ sub show_build_log {
     while (@pagers) {
         $pager = shift @pagers;
         next unless $pager;
-        $pager = which($pager);
+        $pager = Menlo::Util::which($pager, 1);
         next unless $pager;
         last;
     }
@@ -2692,13 +2691,13 @@ sub init_tools {
 
     return if $self->{initialized}++;
 
-    if ($self->{make} = which($Config{make})) {
+    if ($self->{make} = Menlo::Util::which($Config{make})) {
         $self->chat("You have make $self->{make}\n");
     }
 
     $self->{http} = $self->configure_http;
 
-    my $tar = which('tar');
+    my $tar = Menlo::Util::which('tar', 1);
     my $tar_ver;
     my $maybe_bad_tar = sub { WIN32 || BAD_TAR || (($tar_ver = `$tar --version 2>/dev/null`) =~ /GNU.*1\.13/i) };
 
@@ -2733,8 +2732,8 @@ sub init_tools {
             return undef;
         }
     } elsif (    $tar
-             and my $gzip = which('gzip')
-             and my $bzip2 = which('bzip2')) {
+             and my $gzip = Menlo::Util::which('gzip', 1)
+             and my $bzip2 = Menlo::Util::which('bzip2', 1)) {
         $self->chat("You have $tar, $gzip and $bzip2\n");
         $self->{_backends}{untar} = sub {
             my($self, $tarfile) = @_;
@@ -2788,7 +2787,7 @@ sub init_tools {
         };
     }
 
-    if (my $unzip = which('unzip')) {
+    if (my $unzip = Menlo::Util::which('unzip', 1)) {
         $self->chat("You have $unzip\n");
         $self->{_backends}{unzip} = sub {
             my($self, $zipfile) = @_;

--- a/lib/Menlo/CLI/Compat.pm
+++ b/lib/Menlo/CLI/Compat.pm
@@ -918,7 +918,7 @@ sub run_command {
     if (WIN32) {
         $cmd = safe_string($cmd) if ref $cmd eq 'ARRAY';
         unless ($self->{verbose}) {
-            $cmd .= " " . safe_string(">>", [$self->{log}], "2>&1");
+            $cmd .= " >> " . Menlo::Util::shell_quote($self->{log}) . " 2>&1";
         }
         !system $cmd;
     } else {
@@ -945,7 +945,7 @@ sub run_exec {
         exec { $cmd->[0] } @$cmd;
     } else {
         unless ($self->{verbose}) {
-            $cmd .= " " . safe_string(">>", [$self->{log}], "2>&1");
+            $cmd .= " >> " . Menlo::Util::shell_quote($self->{log}) . " 2>&1";
         }
         exec $cmd;
     }

--- a/lib/Menlo/CLI/Compat.pm
+++ b/lib/Menlo/CLI/Compat.pm
@@ -2739,7 +2739,7 @@ sub init_tools {
         $self->{_backends}{untar} = sub {
             my($self, $tarfile) = @_;
 
-            my $x  = "x" . ($self->{verbose} ? 'v' : '') . "f -";
+            my $x  = "x" . ($self->{verbose} ? 'v' : '') . "f";
             my $ar = $tarfile =~ /bz2$/ ? $bzip2 : $gzip;
 
             my($root, @others) = safe_capture([$ar, "-dc", $tarfile], "|", [$tar, "tf", "-"])
@@ -2757,7 +2757,7 @@ sub init_tools {
                 }
             }
 
-            safe_system([$ar, "-dc", $tarfile], "|", [$tar, $x]);
+            safe_system([$ar, "-dc", $tarfile], "|", [$tar, $x, "-"]);
             return $root if -d $root;
 
             $self->diag_fail("Bad archive: $tarfile");

--- a/lib/Menlo/CLI/Compat.pm
+++ b/lib/Menlo/CLI/Compat.pm
@@ -2793,14 +2793,14 @@ sub init_tools {
         $self->{_backends}{unzip} = sub {
             my($self, $zipfile) = @_;
 
-            my $opt = $self->{verbose} ? '' : '-q';
+            my @opt = $self->{verbose} ? () : ('-q');
             my(undef, $root, @others) = safe_capture([$unzip, "-t", $zipfile])
                 or return undef;
 
             chomp $root;
             $root =~ s{^\s+testing:\s+([^/]+)/.*?\s+OK$}{$1};
 
-            safe_system([$unzip, $opt, $zipfile]);
+            safe_system([$unzip, @opt, $zipfile]);
             return $root if -d $root;
 
             $self->diag_fail("Bad archive: '$root' $zipfile");

--- a/lib/Menlo/CLI/Compat.pm
+++ b/lib/Menlo/CLI/Compat.pm
@@ -942,7 +942,7 @@ sub run_exec {
             open STDOUT, '>&', $logfh;
             close $logfh;
         }
-        exec @$cmd;
+        exec { $cmd->[0] } @$cmd;
     } else {
         unless ($self->{verbose}) {
             $cmd .= " " . safe_string(">>", [$self->{log}], "2>&1");

--- a/lib/Menlo/Util.pm
+++ b/lib/Menlo/Util.pm
@@ -1,6 +1,7 @@
 package Menlo::Util;
 use strict;
 
+use File::Which ();
 use Exporter;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(WIN32);
@@ -13,6 +14,14 @@ if (WIN32) {
 } else {
     require String::ShellQuote;
     *shell_quote = \&String::ShellQuote::shell_quote_best_effort;
+}
+
+sub which {
+    my($name, $quote) = @_;
+    my $path = File::Which::which($name);
+    return unless $path;
+    return $path unless $quote;
+    $path =~ /\s/ ? shell_quote($path) : $path;
 }
 
 1;

--- a/lib/Menlo/Util.pm
+++ b/lib/Menlo/Util.pm
@@ -3,7 +3,7 @@ use strict;
 
 use Exporter;
 our @ISA = qw(Exporter);
-our @EXPORT_OK = qw(WIN32);
+our @EXPORT_OK = qw(WIN32 safe_string safe_system safe_capture);
 
 use constant WIN32 => $^O eq 'MSWin32';
 
@@ -15,5 +15,18 @@ if (WIN32) {
     *shell_quote = \&String::ShellQuote::shell_quote_best_effort;
 }
 
-1;
+sub safe_string {
+    join ' ', map { ref $_ ? shell_quote(@$_) : $_ } @_;
+}
 
+sub safe_system {
+    my $cmd = safe_string(@_);
+    system $cmd;
+}
+
+sub safe_capture {
+    my $cmd = safe_string(@_);
+    `$cmd`;
+}
+
+1;

--- a/lib/Menlo/Util.pm
+++ b/lib/Menlo/Util.pm
@@ -1,7 +1,6 @@
 package Menlo::Util;
 use strict;
 
-use File::Which ();
 use Exporter;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(WIN32);
@@ -14,14 +13,6 @@ if (WIN32) {
 } else {
     require String::ShellQuote;
     *shell_quote = \&String::ShellQuote::shell_quote_best_effort;
-}
-
-sub which {
-    my($name, $quote) = @_;
-    my $path = File::Which::which($name);
-    return unless $path;
-    return $path unless $quote;
-    $path =~ /\s/ ? shell_quote($path) : $path;
 }
 
 1;


### PR DESCRIPTION
Address #545  again.

* Quote cpansign/pager/tar/gzip/bzip2/unzip if it contains spaces.
* But do not quote $Config{make}, because it will be quoted  
in run_command / ~~run_exec~~ append_args if necessary. (Edited)

I confirmed that with this change, cpanm-menlo works fine in appveyor
https://ci.appveyor.com/project/skaji/cpm/build/1.0.13