### PR TITLE
Avoid to redefine existing variable

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1870,9 +1870,9 @@ sub resolve_name {
 }
 
 sub cpan_module {
-    my($self, $module, $dist, $version) = @_;
+    my($self, $module, $dist_file, $version) = @_;
 
-    my $dist = $self->cpan_dist($dist);
+    my $dist = $self->cpan_dist($dist_file);
     $dist->{module} = $module;
     $dist->{module_version} = $version if $version && $version ne 'undef';
 


### PR DESCRIPTION
cpan_module function was using two
'my $dist', we only need one.