### PR TITLE
Take care of zipfiles that have comments

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -3125,9 +3125,13 @@ sub init_tools {
             my $opt = $self->{verbose} ? '' : '-q';
             my(undef, $root, @others) = `$unzip -t $zipfile`
                 or return undef;
-
-            chomp $root;
-            $root =~ s{^\s+testing:\s+([^/]+)/.*?\s+OK$}{$1};
+            FILE: {
+                chomp $root;
+                if ($root !~ s{^\s+testing:\s+([^/]+)/.*?\s+OK$}{$1}) {
+                    $root = shift(@others);
+                    redo FILE if $root;
+                }
+            }
 
             system "$unzip $opt $zipfile";
             return $root if -d $root;

--- a/xt/zip_root.t
+++ b/xt/zip_root.t
@@ -8,4 +8,7 @@ unlike last_build_log, qr/Bad archive/;
 run 'CPAN::Test::Dummy::Perl5::Make::Zip';
 like last_build_log, qr/installed/;
 
+run 'JJONES/Finance-OFX-Parse-Simple-0.07.zip';
+like last_build_log, qr/installed/;
+
 done_testing;


### PR DESCRIPTION
Fix #559 

As described in #559, `unzip -t zipfile` may have some comment lines.
```
❯ wget -q http://www.cpan.org/authors/id/J/JJ/JJONES/Finance-OFX-Parse-Simple-0.07.zip

❯ unzip -t Finance-OFX-Parse-Simple-0.07.zip
Archive:  Finance-OFX-Parse-Simple-0.07.zip
f5019eed24b24c4cb8de55c5db3384aa9d251f09
    testing: Finance--OFX--Parse--Simple-master/   OK
    testing: Finance--OFX--Parse--Simple-master/Changes   OK
    testing: Finance--OFX--Parse--Simple-master/MANIFEST   OK
    testing: Finance--OFX--Parse--Simple-master/META.yml   OK
    testing: Finance--OFX--Parse--Simple-master/Makefile.PL   OK
    testing: Finance--OFX--Parse--Simple-master/README   OK
    testing: Finance--OFX--Parse--Simple-master/README.md   OK
    testing: Finance--OFX--Parse--Simple-master/lib/   OK
    testing: Finance--OFX--Parse--Simple-master/lib/Finance/   OK
    testing: Finance--OFX--Parse--Simple-master/lib/Finance/OFX/   OK
    testing: Finance--OFX--Parse--Simple-master/lib/Finance/OFX/Parse/   OK
    testing: Finance--OFX--Parse--Simple-master/lib/Finance/OFX/Parse/Simple.pm   OK
    testing: Finance--OFX--Parse--Simple-master/t/   OK
    testing: Finance--OFX--Parse--Simple-master/t/00-load.t   OK
    testing: Finance--OFX--Parse--Simple-master/t/01-main.t   OK
    testing: Finance--OFX--Parse--Simple-master/t/pod-coverage.t   OK
    testing: Finance--OFX--Parse--Simple-master/t/pod.t   OK
No errors detected in compressed data of Finance-OFX-Parse-Simple-0.07.zip.
```
This PR change the code to retry the detection of root directory.