### PR TITLE
When exec returns false exit needs calling.

### DIFF
--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1190,7 +1190,10 @@ sub run_exec {
             open STDOUT, '>&', $logfh;
             close $logfh;
         }
-        exec @$cmd;
+        exec { @$cmd[0] } @$cmd or sub {
+            $self->diag_fail("Failed to run '@$cmd' $!");
+            exit(1);
+        }->();
     } else {
         unless ($self->{verbose}) {
             $cmd .= " >> " . $self->shell_quote($self->{log}) . " 2>&1";

--- a/xt/run.t
+++ b/xt/run.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw(tempdir);
+use App::cpanminus::script;
+
+$ENV{PERL_CPANM_HOME} = tempdir(CLEANUP => 1);
+local $| = 1;
+my $script = new_ok('App::cpanminus::script',
+  [verbose => 0, log => "$ENV{PERL_CPANM_HOME}/build.log"]);
+
+is $script->run(['not-a-command', 'that runs']), '', "nothing good here";
+is $script->run('not-a-command that runs'), '', "nothing good here again";
+
+is $script->run('echo hello world'), 1, 'good';
+is $script->run([qw{echo hello world}]), 1, 'ran ok';
+
+my @lines;
+open my $fh, '<', $script->{log};
+while(<$fh>) { push @lines, $_; }
+
+like $lines[0], qr/Failed\sto\srun/, 'failed to run message';
+like $lines[1], qr/FAIL\sFailed\sto\srun/, 'failed to run message';
+like $lines[2], qr/^sh:\snot\-a\-command/, 'failed through shell';
+like $lines[3], qr/^hello\sworld/, 'success';
+like $lines[4], qr/^hello\sworld/, 'success';
+
+done_testing;


### PR DESCRIPTION
This ensures that the `fork()`ed child is cleaned up.

This pull request adds the call to `exit()` and a helpful message will be reported on the case of failure.