### PR TITLE
Support 'dist', 'mirror' and 'url' option in cpanfile

### DIFF
--- a/App-cpanminus/testdist/cpanfile_dist/cpanfile
+++ b/App-cpanminus/testdist/cpanfile_dist/cpanfile
@@ -1,0 +1,2 @@
+requires 'Hash::MultiValue', dist => "MIYAGAWA/Hash-MultiValue-0.15.tar.gz";
+requires 'Path::Class', 0.26, dist => "KWILLIAMS/Path-Class-0.26.tar.gz";

--- a/App-cpanminus/testdist/cpanfile_dist/cpanfile
+++ b/App-cpanminus/testdist/cpanfile_dist/cpanfile
@@ -1,2 +1,15 @@
-requires 'Hash::MultiValue', dist => "MIYAGAWA/Hash-MultiValue-0.15.tar.gz";
-requires 'Path::Class', 0.26, dist => "KWILLIAMS/Path-Class-0.26.tar.gz";
+requires 'Path::Class', 0.26,
+  dist => "KWILLIAMS/Path-Class-0.26.tar.gz";
+
+# omit version specifier
+requires 'Hash::MultiValue',
+  dist => "MIYAGAWA/Hash-MultiValue-0.15.tar.gz";
+
+# use dist + mirror
+requires 'Cookie::Baker',
+  dist => "KAZEBURO/Cookie-Baker-0.08.tar.gz",
+  mirror => "http://cpan.cpantesters.org/";
+
+# use the full URL
+requires 'Try::Tiny', 0.28,
+  url => "http://backpan.perl.org/authors/id/E/ET/ETHER/Try-Tiny-0.28.tar.gz";

--- a/App-cpanminus/xt/cpanfile_dist.t
+++ b/App-cpanminus/xt/cpanfile_dist.t
@@ -1,0 +1,12 @@
+use strict;
+use Test::More;
+use xt::Run;
+
+{
+    run_L "--installdeps", "./testdist/cpanfile_dist";
+
+    like last_build_log, qr/installed Hash-MultiValue-0\.15/;
+    like last_build_log, qr/installed Path-Class-0\.26/;
+}
+
+done_testing;

--- a/App-cpanminus/xt/cpanfile_dist.t
+++ b/App-cpanminus/xt/cpanfile_dist.t
@@ -7,6 +7,13 @@ use xt::Run;
 
     like last_build_log, qr/installed Hash-MultiValue-0\.15/;
     like last_build_log, qr/installed Path-Class-0\.26/;
+
+    like last_build_log, qr/installed Cookie-Baker-0\.08/;
+    like last_build_log, qr!Fetching \Qhttp://cpan.cpantesters.org/authors/id/K/KA/KAZEBURO/Cookie-Baker-0.08.tar.gz\E!;
+
+    like last_build_log, qr/installed Try-Tiny-0\.28/;
+    like last_build_log, qr!Fetching \Qhttp://backpan.perl.org/authors/id/E/ET/ETHER/Try-Tiny-0.28.tar.gz\E!;
+
 }
 
 done_testing;

--- a/Menlo/lib/Menlo/Dependency.pm
+++ b/Menlo/lib/Menlo/Dependency.pm
@@ -1,7 +1,7 @@
 package Menlo::Dependency;
 use strict;
 use CPAN::Meta::Requirements;
-use Class::Tiny qw( module version type original_version dist );
+use Class::Tiny qw( module version type original_version dist mirror url );
 
 sub BUILDARGS {
     my($class, $module, $version, $type) = @_;

--- a/Menlo/lib/Menlo/Dependency.pm
+++ b/Menlo/lib/Menlo/Dependency.pm
@@ -1,7 +1,7 @@
 package Menlo::Dependency;
 use strict;
 use CPAN::Meta::Requirements;
-use Class::Tiny qw( module version type original_version );
+use Class::Tiny qw( module version type original_version dist );
 
 sub BUILDARGS {
     my($class, $module, $version, $type) = @_;


### PR DESCRIPTION
This PR adds support for the `dist`, `mirror` and `url` option in cpanfile, to enforce the resolution of a given module to a specific CPAN distribution.

```
requires 'Path::Class', 0.26,
  dist => "KWILLIAMS/Path-Class-0.26.tar.gz";

# omit version specifier
requires 'Hash::MultiValue',
  dist => "MIYAGAWA/Hash-MultiValue-0.15.tar.gz";

# use dist + mirror
requires 'Cookie::Baker',
  dist => "KAZEBURO/Cookie-Baker-0.08.tar.gz",
  mirror => "http://cpan.cpantesters.org/";

# use the full URL
requires 'Try::Tiny', 0.28,
  url => "http://backpan.perl.org/authors/id/E/ET/ETHER/Try-Tiny-0.28.tar.gz";
```

Like normally, cpanm will see if the module needs to be installed by looking at the version specification. In the case of first one, the version specification is omitted, and 0 is assumed. (The check is done in Module::CPANfile by counting the number of arguments)

There could be an argument whether this should be done in Carton, Carmel or cpm, but doing this in cpanm + cpanfile allows this to be usable in all of them, while allowing these tools to override the behavior if they want.

I know some people who uses a specific CPAN URIs in `cpanfile` to essentially do this, which accidentally works.