### PR TITLE
Account for failed fetches with body in HTTP req

### DIFF
--- a/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
+++ b/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
@@ -1427,8 +1427,11 @@ sub fetch_module {
             my $file;
             eval {
                 local $SIG{INT} = sub { $cancelled = 1; die "SIGINT\n" };
-                $self->mirror($uri, $name);
-                $file = $name if -e $name;
+                if ($self->mirror($uri, $name)->{success} && -e $name) {
+                    $file = $name;
+                } else {
+                    unlink $name;
+                }
             };
             $self->diag("ERROR: " . trim("$@") . "\n", 1) if $@ && $@ ne "SIGINT\n";
             return $file;


### PR DESCRIPTION
Eg. a 404 that may contain a message in JSON
- LWP::UserAgent will not replace the local file if it is newer than
  a successful dist archive