### PR TITLE
Add requirement of version 0.9905

### DIFF
--- a/Menlo-Legacy/cpanfile
+++ b/Menlo-Legacy/cpanfile
@@ -2,6 +2,8 @@ requires 'perl', '5.008001';
 
 requires 'Menlo', '1.9018';
 
+requires 'version', '0.9905';
+
 on test => sub {
     requires 'Test::More', '0.96';
 };


### PR DESCRIPTION
Menlo::CLI::Compat needs version::vpp if running under App::FatPacker.
If version::vpp is not installed, then Menlo::CLI::Compat cannot be
fat-packed.  Fix by declaring dependency on version 0.9905 (which from
Changes, appears to be a sane version that installs the pure-perl
implementation even if the XS version gets installed).