### PR TITLE
shorten the homedir logic, removing the need for File::HomeDir

### DIFF
--- a/App-cpanminus/META.json
+++ b/App-cpanminus/META.json
@@ -37,7 +37,6 @@
             "Archive::Tar" : "0",
             "Archive::Zip" : "0",
             "Compress::Zlib" : "0",
-            "File::HomeDir" : "0",
             "LWP::UserAgent" : "5.802",
             "Module::Signature" : "0"
          },

--- a/App-cpanminus/cpanfile
+++ b/App-cpanminus/cpanfile
@@ -18,7 +18,6 @@ on develop => sub {
     recommends 'Archive::Tar';
     recommends 'Archive::Zip';
     recommends 'Compress::Zlib';
-    recommends 'File::HomeDir';
     recommends 'LWP::UserAgent', '5.802';
     recommends 'Module::Signature';
 };

--- a/App-cpanminus/fatpack-build/cpanfile
+++ b/App-cpanminus/fatpack-build/cpanfile
@@ -37,7 +37,6 @@ requires 'version';
 suggests 'LWP::UserAgent', '5.802';
 suggests 'Archive::Tar';
 suggests 'Archive::Zip';
-suggests 'File::HomeDir';
 suggests 'Module::Signature';
 suggests 'Digest::SHA';
 

--- a/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
+++ b/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
@@ -32,11 +32,11 @@ sub qs($) {
 sub determine_home {
     my $class = shift;
 
-    my $homedir = $ENV{HOME}
-      || eval { require File::HomeDir; File::HomeDir->my_home }
-      || join('', @ENV{qw(HOMEDRIVE HOMEPATH)}); # Win32
+    my $homedir = $^O eq 'MSWin32' && "$]" < 5.016
+        ? $ENV{HOME} || $ENV{USERPROFILE}
+        : (<~>)[0];
 
-    if (WIN32) {
+    if (WIN32 and not $homedir) {
         require Win32; # no fatpack
         $homedir = Win32::GetShortPathName($homedir);
     }

--- a/Menlo/META.json
+++ b/Menlo/META.json
@@ -76,7 +76,6 @@
             "Archive::Tar" : "0",
             "Archive::Zip" : "0",
             "Digest::SHA" : "0",
-            "File::HomeDir" : "0",
             "LWP::UserAgent" : "5.802",
             "Module::Signature" : "0"
          }

--- a/Menlo/cpanfile
+++ b/Menlo/cpanfile
@@ -37,7 +37,6 @@ requires 'version';
 suggests 'LWP::UserAgent', '5.802';
 suggests 'Archive::Tar';
 suggests 'Archive::Zip';
-suggests 'File::HomeDir';
 suggests 'Module::Signature';
 suggests 'Digest::SHA';
 


### PR DESCRIPTION
This follows the logic explained in File::HomeDir::Tiny.