### PR TITLE
Remove useless /d modifier when triming string

### DIFF
--- a/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
+++ b/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
@@ -1399,7 +1399,7 @@ sub format_dist {
 
 sub trim {
     local $_ = shift;
-    tr/\n/ /d;
+    tr/\n/ /;
     s/^\s*|\s*$//g;
     $_;
 }


### PR DESCRIPTION
Resolves #592

Useless use of /d modifier in transliteration operator
since Perl 5.012. Not sure we need it for versions
before.

Note: need to regenerate cpanm once merged, I was trying to avoid doing it as part of this Pull Request.