### PR TITLE
Explicitly require version::vpp

### DIFF
--- a/Menlo-Legacy/cpanfile
+++ b/Menlo-Legacy/cpanfile
@@ -3,6 +3,7 @@ requires 'perl', '5.008001';
 requires 'Menlo', '1.9018';
 
 requires 'version', '0.9905';
+requires 'version::vpp', '0.9905';
 
 on test => sub {
     requires 'Test::More', '0.96';


### PR DESCRIPTION
Some perl versions bundle "version" but do not include "version::vpp".
Fix by explicitly requiring version::vpp.

Should be a better fix for perl-carton/carton#237