### PR TITLE
Resolve module from name and mirror URL

### DIFF
--- a/App-cpanminus/testdist/cpanfile_mirror/cpanfile
+++ b/App-cpanminus/testdist/cpanfile_mirror/cpanfile
@@ -1,0 +1,6 @@
+# -*- mode: perl; -*-
+# use mirror
+requires 'Hash::MultiValue' => '== 0.08', 
+  mirror => "https://kiwiroy.github.io/PPAN/mock";
+
+requires 'Try::Tiny' => '== 0.30';

--- a/App-cpanminus/xt/cpanfile_dist.t
+++ b/App-cpanminus/xt/cpanfile_dist.t
@@ -17,4 +17,18 @@ use xt::Run;
 
 }
 
+{
+    run_L "--installdeps", "./testdist/cpanfile_mirror";
+
+    # downgrade from mirror
+    like last_build_log, qr{Fetching \Qhttps://kiwiroy.github.io/PPAN/mock/authors/id/M/MY/MY/Hash-MultiValue-0.08.tar.gz\E};
+    like last_build_log, qr/installed Hash-MultiValue-0\.08/;
+
+    # upgrade from cpan
+    like last_build_log, qr{Fetching \Qhttp://cpan.metacpan.org/authors/id/E/ET/ETHER/Try-Tiny-0.30.tar.gz\E};
+    like last_build_log, qr/installed Try-Tiny-/;
+
+    # diag last_build_log;
+}
+
 done_testing;

--- a/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
+++ b/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
@@ -1603,6 +1603,15 @@ sub resolve_name {
         return $self->cpan_dist($dep->dist, undef, $dep->mirror);
     }
 
+    if ($dep && $dep->mirror) {
+        local $self->{mirrors} = [
+            $dep->mirror,
+            !$self->{mirror_only} ? @{$self->{mirrors}} : ()
+            ];
+        local $self->{mirror_only} = 1;
+        return $self->search_module($module, $version);
+    }
+
     # Git
     if ($module =~ /(?:^git:|\.git(?:@.+)?$)/) {
         return $self->git_uri($module);


### PR DESCRIPTION
Currently if a `Menlo::Dependency` has a `mirror`, but no `dist` the mirror is ignored. It should be possible to query the specific mirror for the module as happens for the default CPAN.

This PR enables that and works with miyagawa/cpanfile#54