### PR TITLE
Change "SHA1" to "SHA256" in chat message when verifying checksum

### DIFF
--- a/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
+++ b/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
@@ -1529,7 +1529,7 @@ sub verify_archive {
 sub verify_checksum {
     my($self, $file, $chk_file) = @_;
 
-    $self->chat("Verifying the SHA1 for $file\n");
+    $self->chat("Verifying the SHA256 for $file\n");
 
     open my $fh, "<$chk_file" or die "$chk_file: $!";
     my $data = join '', <$fh>;


### PR DESCRIPTION
Which is the actual digest algorithm used