### PR TITLE
Add Perl::Version dependency to cpanfile

### DIFF
--- a/App-cpanminus/cpanfile
+++ b/App-cpanminus/cpanfile
@@ -13,6 +13,7 @@ on develop => sub {
     # for fatpacking
     requires 'App::FatPacker';
     requires 'Perl::Strip';
+    requires 'Perl::Version';
     requires 'Tie::File';
 
     recommends 'Archive::Tar';

--- a/App-cpanminus/maint/bump_fatpack.pl
+++ b/App-cpanminus/maint/bump_fatpack.pl
@@ -3,6 +3,8 @@
 use strict;
 use warnings;
 
+use Perl::Version (); # provides perl-reversion
+
 sub find_version {
     my $file = shift;
 


### PR DESCRIPTION
Add an extra use statement in maint/bump_fatpack.pl
to die earlier when Perl::Version is missing.