### PR TITLE
2 changes in verify_checksums/verify_checksums_signature

### DIFF
--- a/App-cpanminus/xt/verify_checksums.t
+++ b/App-cpanminus/xt/verify_checksums.t
@@ -3,6 +3,26 @@ use lib ".";
 use xt::Run;
 use Test::More;
 
+use File::Temp ();
+use File::Which ();
+use HTTP::Tinyish;
+
+my $gpg = File::Which::which "gpg";
+
+plan skip_all => 'need gpg' if !$gpg;
+
+{
+    # XXX As of 2021-11-29, Module::Signature does not bundle PAUSE2022.pub,
+    # so we should import PAUSE2022 by ourselves
+    my $url = "https://raw.githubusercontent.com/andk/cpanpm/master/PAUSE2022.pub";
+    my $res = HTTP::Tinyish->new->get($url);
+    die "$res->{status} $res->{reason}, $url\n" if !$res->{success};
+    my $tempfile = File::Temp->new;
+    $tempfile->print($res->{content});
+    $tempfile->close;
+    !system $gpg, "--quiet", "--import", $tempfile->filename or die;
+}
+
 run "--reinstall", "--verify", "URI";
 like last_build_log, qr/Fetching.*CHECKSUMS/;
 like last_build_log, qr/Checksum.*Verified/;

--- a/App-cpanminus/xt/verify_signature.t
+++ b/App-cpanminus/xt/verify_signature.t
@@ -3,6 +3,26 @@ use lib ".";
 use xt::Run;
 use Test::More;
 
+use File::Temp ();
+use File::Which ();
+use HTTP::Tinyish;
+
+my $gpg = File::Which::which "gpg";
+
+plan skip_all => 'need gpg' if !$gpg;
+
+{
+    # XXX As of 2021-11-29, Module::Signature does not bundle PAUSE2022.pub,
+    # so we should import PAUSE2022 by ourselves
+    my $url = "https://raw.githubusercontent.com/andk/cpanpm/master/PAUSE2022.pub";
+    my $res = HTTP::Tinyish->new->get($url);
+    die "$res->{status} $res->{reason}, $url\n" if !$res->{success};
+    my $tempfile = File::Temp->new;
+    $tempfile->print($res->{content});
+    $tempfile->close;
+    !system $gpg, "--quiet", "--import", $tempfile->filename or die;
+}
+
 run "--reinstall", "--verify", "Module::Signature";
 like last_build_log, qr/Verifying the SIGNATURE/;
 like last_build_log, qr/Verified OK/;

--- a/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
+++ b/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
@@ -1523,11 +1523,11 @@ sub verify_archive {
 
     $self->diag_ok;
     $self->verify_checksums_signature($chk_file) or return;
-    $self->verify_checksum($file, $chk_file);
+    $self->verify_checksum($file, $uri, $chk_file);
 }
 
 sub verify_checksum {
-    my($self, $file, $chk_file) = @_;
+    my($self, $file, $uri, $chk_file) = @_;
 
     $self->chat("Verifying the SHA256 for $file\n");
 
@@ -1543,14 +1543,19 @@ sub verify_checksum {
         return;
     }
 
-    if (my $sha = $chksum->{$file}{sha256}) {
-        my $hex = $self->sha_for(256, $file);
-        if ($hex eq $sha) {
-            $self->chat("Checksum for $file: Verified!\n");
-        } else {
+    if (my $found = $chksum->{$file}) {
+        my ($cpan_path) = $uri =~ m{\A.*/authors/id/(.+)/[^/]+\z};
+        if ($cpan_path ne $found->{cpan_path}) {
+            $self->diag_fail("cpan_path mismatch for $file\n");
+            return;
+        }
+        my $sha256 = $self->sha_for(256, $file);
+        if ($sha256 ne $found->{sha256}) {
             $self->diag_fail("Checksum mismatch for $file\n");
             return;
         }
+        $self->chat("Checksum for $file: Verified!\n");
+        return 1;
     } else {
         $self->chat("Checksum for $file not found in CHECKSUMS.\n");
         return;

--- a/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
+++ b/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
@@ -1488,12 +1488,12 @@ sub verify_checksums_signature {
 
     my $rv = eval {
         local $SIG{__WARN__} = sub {}; # suppress warnings
-        my $v = Module::Signature::_verify($chk_file);
-        $v == Module::Signature::SIGNATURE_OK();
+        Module::Signature::_verify($chk_file);
     };
-    if ($rv) {
+    if (defined $rv && $rv eq Module::Signature::SIGNATURE_OK()) {
         $self->chat("Verified OK!\n");
     } else {
+        $rv = "(undef)" unless defined $rv;
         $self->diag_fail("Verifying CHECKSUMS signature failed: $rv\n");
         return;
     }


### PR DESCRIPTION
This PR do 2 things in verify_checksums/verify_checksums_signature:

* Module::Signature::_verify may return SIGNATURE_OK (0), and also CANNOT_VERIFY ('0E0'). So we should use "eq" to test the return values. See https://metacpan.org/release/AUDREYT/Module-Signature-0.87/source/lib/Module/Signature.pm#L11-12
* check cpan_path in CHECKSUMS file too; this makes sure CHECKSUMS file is actually for the "AUTHOR" in question.

In addition, we import PAUSE2022.pub by ourselves in tests;
this workaround will be safely deleted once Module::Signature itself bundles the key. See https://github.com/audreyt/module-signature/pull/31