### PR TITLE
do not import PAUSE2022.pub by ourselves

### DIFF
--- a/App-cpanminus/cpanfile
+++ b/App-cpanminus/cpanfile
@@ -21,5 +21,5 @@ on develop => sub {
     recommends 'Compress::Zlib';
     recommends 'File::HomeDir';
     recommends 'LWP::UserAgent', '5.802';
-    recommends 'Module::Signature';
+    recommends 'Module::Signature', '0.88';
 };

--- a/App-cpanminus/xt/verify_checksums.t
+++ b/App-cpanminus/xt/verify_checksums.t
@@ -3,26 +3,6 @@ use lib ".";
 use xt::Run;
 use Test::More;
 
-use File::Temp ();
-use File::Which ();
-use HTTP::Tinyish;
-
-my $gpg = File::Which::which "gpg";
-
-plan skip_all => 'need gpg' if !$gpg;
-
-{
-    # XXX As of 2021-11-29, Module::Signature does not bundle PAUSE2022.pub,
-    # so we should import PAUSE2022 by ourselves
-    my $url = "https://raw.githubusercontent.com/andk/cpanpm/master/PAUSE2022.pub";
-    my $res = HTTP::Tinyish->new->get($url);
-    die "$res->{status} $res->{reason}, $url\n" if !$res->{success};
-    my $tempfile = File::Temp->new;
-    $tempfile->print($res->{content});
-    $tempfile->close;
-    !system $gpg, "--quiet", "--import", $tempfile->filename or die;
-}
-
 run "--reinstall", "--verify", "URI";
 like last_build_log, qr/Fetching.*CHECKSUMS/;
 like last_build_log, qr/Checksum.*Verified/;

--- a/App-cpanminus/xt/verify_signature.t
+++ b/App-cpanminus/xt/verify_signature.t
@@ -3,26 +3,6 @@ use lib ".";
 use xt::Run;
 use Test::More;
 
-use File::Temp ();
-use File::Which ();
-use HTTP::Tinyish;
-
-my $gpg = File::Which::which "gpg";
-
-plan skip_all => 'need gpg' if !$gpg;
-
-{
-    # XXX As of 2021-11-29, Module::Signature does not bundle PAUSE2022.pub,
-    # so we should import PAUSE2022 by ourselves
-    my $url = "https://raw.githubusercontent.com/andk/cpanpm/master/PAUSE2022.pub";
-    my $res = HTTP::Tinyish->new->get($url);
-    die "$res->{status} $res->{reason}, $url\n" if !$res->{success};
-    my $tempfile = File::Temp->new;
-    $tempfile->print($res->{content});
-    $tempfile->close;
-    !system $gpg, "--quiet", "--import", $tempfile->filename or die;
-}
-
 run "--reinstall", "--verify", "Module::Signature";
 like last_build_log, qr/Verifying the SIGNATURE/;
 like last_build_log, qr/Verified OK/;

--- a/Menlo/cpanfile
+++ b/Menlo/cpanfile
@@ -38,7 +38,7 @@ suggests 'LWP::UserAgent', '5.802';
 suggests 'Archive::Tar';
 suggests 'Archive::Zip';
 suggests 'File::HomeDir';
-suggests 'Module::Signature';
+suggests 'Module::Signature', '0.88';
 suggests 'Digest::SHA';
 
 on test => sub {


### PR DESCRIPTION
[Module::Signature 0.88](https://metacpan.org/release/AUDREYT/Module-Signature-0.88) now bundles PAUSE2022.pub,
so we don't need to import PAUSE2022.pub by ourselves anymore.