### PR TITLE
[CVE-2020-16154] remove the functionality to verify CHECKSUMS signature

### DIFF
--- a/App-cpanminus/script/cpanm.PL
+++ b/App-cpanminus/script/cpanm.PL
@@ -515,7 +515,7 @@ Defaults to false.
 
 =item --verify
 
-Verify the integrity of distribution files retrieved from PAUSE using CHECKSUMS
+Verify the integrity of distribution files retrieved from CPAN using CHECKSUMS
 file, and SIGNATURES (if found in the distribution). Defaults to false.
 
 Using this option does not verify the integrity of the CHECKSUMS file, and it's

--- a/App-cpanminus/script/cpanm.PL
+++ b/App-cpanminus/script/cpanm.PL
@@ -515,8 +515,12 @@ Defaults to false.
 
 =item --verify
 
-Verify the integrity of distribution files retrieved from PAUSE using
-CHECKSUMS and SIGNATURES (if found). Defaults to false.
+Verify the integrity of distribution files retrieved from PAUSE using CHECKSUMS
+file, and SIGNATURES (if found in the distribution). Defaults to false.
+
+Using this option does not verify the integrity of the CHECKSUMS file, and it's
+unsafe to rely on this option if you're using a CPAN mirror that you do not
+trust.
 
 =item --report-perl-version
 

--- a/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
+++ b/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
@@ -1479,28 +1479,6 @@ sub unpack {
     return $dir;
 }
 
-sub verify_checksums_signature {
-    my($self, $chk_file) = @_;
-
-    require Module::Signature; # no fatpack
-
-    $self->chat("Verifying the signature of CHECKSUMS\n");
-
-    my $rv = eval {
-        local $SIG{__WARN__} = sub {}; # suppress warnings
-        Module::Signature::_verify($chk_file);
-    };
-    if (defined $rv && $rv eq Module::Signature::SIGNATURE_OK()) {
-        $self->chat("Verified OK!\n");
-    } else {
-        $rv = "(undef)" unless defined $rv;
-        $self->diag_fail("Verifying CHECKSUMS signature failed: $rv\n");
-        return;
-    }
-
-    return 1;
-}
-
 sub verify_archive {
     my($self, $file, $uri, $dist) = @_;
 
@@ -1522,7 +1500,6 @@ sub verify_archive {
     }
 
     $self->diag_ok;
-    $self->verify_checksums_signature($chk_file) or return;
     $self->verify_checksum($file, $uri, $chk_file);
 }
 


### PR DESCRIPTION
This PR removes the functionality to verify the signature of CHECKSUMS files, since it's been known that there're certain ways to bypass the check.

While @skaji et al have fixed a particular issue leading to the CVE, in my opinion the use of self-contained PGP signature to verify the integrity has its design issues, and it's simpler to rely on HTTPS and download the archives from the official CPAN/PAUSE mirrors, as described in the notes as the mitigation:  http://blogs.perl.org/users/neilb/2021/11/addressing-cpan-vulnerabilities-related-to-checksums.html

CHECKSUMS files are still downloaded and checked, to make sure the tarballs are not corrupt in transit, but cpanm won't check if the CHECKSUMS files are signed by PAUSE pgp keys.
