### PR TITLE
Fix typo "condfigure"

### DIFF
--- a/App-cpanminus/Changes
+++ b/App-cpanminus/Changes
@@ -85,7 +85,7 @@ See http://github.com/miyagawa/cpanminus/ for the latest development.
 1.7041  2016-05-08 11:28:31 PDT
    [Improvements]
       - Add environment variables to man pages (Doug Bell) #481
-      - Support --with-configure and --without-condfigure (zebardy) #482
+      - Support --with-configure and --without-configure (zebardy) #482
       - Make file mirror faster (Matthew Horsfall) #499
 
 1.7040  2016-01-07 11:28:07 PST

--- a/Menlo/Changes
+++ b/Menlo/Changes
@@ -113,7 +113,7 @@ See http://github.com/miyagawa/cpanminus/ for the latest development.
 1.7041  2016-05-08 11:28:31 PDT
    [Improvements]
          - Add environment variables to man pages (Doug Bell) #481
-         - Support --with-configure and --without-condfigure (zebardy) #482
+         - Support --with-configure and --without-configure (zebardy) #482
          - Make file mirror faster (Matthew Horsfall) #499
 
 1.7040  2016-01-07 11:28:07 PST


### PR DESCRIPTION
I stumbled upon this typo and checked there are no similar typos:

```console
$ ack 'with(?:out)?[^ ]?(?:dev|con|rec|tes|sug|fea)\w*' -oh | sort | uniq
with-configure
with_configure
with-develop
with_develop
with-feature
without-condfigure     # <<<<<<<<<<<<<<<<<<< typo I found & fixed
without-configure
without-develop
without-feature
without-recommends
without-suggests
with-recommends
with-suggests
```