### PR TITLE
make cpanm secure by default

### DIFF
--- a/App-cpanminus/lib/App/cpanminus.pm
+++ b/App-cpanminus/lib/App/cpanminus.pm
@@ -105,16 +105,16 @@ Module::Build (core in 5.10)
 
 =head2 How does cpanm get/parse/update the CPAN index?
 
-It queries the CPAN Meta DB site at L<http://cpanmetadb.plackperl.org/>.
+It queries the CPAN Meta DB site at L<https://cpanmetadb.plackperl.org/>.
 The site is updated at least every hour to reflect the latest changes
 from fast syncing mirrors. The script then also falls back to query the
-module at L<http://metacpan.org/> using its search API.
+module at L<https://metacpan.org/> using its search API.
 
 Upon calling these API hosts, cpanm (1.6004 or later) will send the
 local perl versions to the server in User-Agent string by default. You
 can turn it off with C<--no-report-perl-version> option. Read more
 about the option with L<cpanm>, and read more about the privacy policy
-about this data collection at L<http://cpanmetadb.plackperl.org/#privacy>
+about this data collection at L<https://cpanmetadb.plackperl.org/#privacy>
 
 Fetched files are unpacked in C<~/.cpanm> and automatically cleaned up
 periodically.  You can configure the location of this with the
@@ -270,7 +270,7 @@ Arnfjord Bjarmason, Eric Wilhelm, Florian Ragwitz and xaicron.
 
 =over 4
 
-=item L<http://github.com/miyagawa/cpanminus> - source code repository, issue tracker
+=item L<https://github.com/miyagawa/cpanminus> - source code repository, issue tracker
 
 =item L<irc://irc.perl.org/#cpanm> - discussions about cpanm and its related tools
 

--- a/App-cpanminus/script/cpanm.PL
+++ b/App-cpanminus/script/cpanm.PL
@@ -37,14 +37,14 @@ cpanm - get, unpack build and install modules from CPAN
 
   cpanm Test::More                                 # install Test::More
   cpanm MIYAGAWA/Plack-0.99_05.tar.gz              # full distribution path
-  cpanm http://example.org/LDS/CGI.pm-3.20.tar.gz  # install from URL
+  cpanm https://example.org/LDS/CGI.pm-3.20.tar.gz # install from URL
   cpanm ~/dists/MyCompany-Enterprise-1.00.tar.gz   # install from a local file
   cpanm --interactive Task::Kensho                 # Configure interactively
   cpanm .                                          # install from local directory
   cpanm --installdeps .                            # install all the deps for the current directory
   cpanm -L extlib Plack                            # install Plack and all non-core deps into extlib
-  cpanm --mirror http://cpan.cpantesters.org/ DBI  # use the fast-syncing mirror
-  cpanm --from https://cpan.metacpan.org/ Plack    # use only the HTTPS mirror
+  cpanm --mirror https://cpan.cpantesters.org/ DBI # use the fast-syncing mirror
+  cpanm --from https://cpan.metacpan.org/ Plack    # use a different mirror
 
 =head1 COMMANDS
 
@@ -60,7 +60,7 @@ will all work as you expect.
     cpanm Plack/Request.pm
     cpanm MIYAGAWA/Plack-1.0000.tar.gz
     cpanm /path/to/Plack-1.0000.tar.gz
-    cpanm http://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA/Plack-0.9990.tar.gz
+    cpanm https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA/Plack-0.9990.tar.gz
     cpanm git://github.com/plack/Plack.git
 
 Additionally, you can use the notation using C<~> and C<@> to specify
@@ -213,7 +213,7 @@ the behaviour from before version 1.7023
 =item --mirror
 
 Specifies the base URL for the CPAN mirror to use, such as
-C<http://cpan.cpantesters.org/> (you can omit the trailing slash). You
+C<https://cpan.cpantesters.org/> (you can omit the trailing slash). You
 can specify multiple mirror URLs by repeating the command line option.
 
 You can use a local directory that has a CPAN mirror structure
@@ -224,7 +224,7 @@ scheme), it is considered as a file scheme as well.
   cpanm --mirror file:///path/to/mirror
   cpanm --mirror ~/minicpan      # Because shell expands ~ to /home/user
 
-Defaults to C<http://www.cpan.org/>.
+Defaults to C<https://www.cpan.org/>.
 
 =item --mirror-only
 
@@ -256,7 +256,7 @@ B<Tip:> It might be useful if you name these options with your shell
 aliases, like:
 
   alias minicpanm='cpanm --from ~/minicpan'
-  alias darkpan='cpanm --from http://mycompany.example.com/DPAN'
+  alias darkpan='cpanm --from https://mycompany.example.com/DPAN'
 
 =item --mirror-index
 

--- a/Menlo-Legacy/META.json
+++ b/Menlo-Legacy/META.json
@@ -9,7 +9,7 @@
       "perl_5"
    ],
    "meta-spec" : {
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec",
       "version" : 2
    },
    "name" : "Menlo-Legacy",

--- a/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
+++ b/Menlo-Legacy/lib/Menlo/CLI/Compat.pm
@@ -65,7 +65,7 @@ sub new {
         mirrors => [],
         mirror_only => undef,
         mirror_index => undef,
-        cpanmetadb => "http://cpanmetadb.plackperl.org/v1.0/",
+        cpanmetadb => "https://cpanmetadb.plackperl.org/v1.0/",
         perl => $^X,
         argv => [],
         local_lib => undef,
@@ -616,7 +616,7 @@ Options:
   --installdeps             Only install dependencies
   --showdeps                Only display direct dependencies
   --reinstall               Reinstall the distribution even if you already have the latest version installed
-  --mirror                  Specify the base URL for the mirror (e.g. http://cpan.cpantesters.org/)
+  --mirror                  Specify the base URL for the mirror (e.g. https://cpan.cpantesters.org/)
   --mirror-only             Use the mirror's index file instead of the CPAN Meta DB
   -M,--from                 Use only this mirror base URL and its index file
   --prompt                  Prompt when configure/build/test fails
@@ -636,18 +636,18 @@ Examples:
 
   cpanm Test::More                                          # install Test::More
   cpanm MIYAGAWA/Plack-0.99_05.tar.gz                       # full distribution path
-  cpanm http://example.org/LDS/CGI.pm-3.20.tar.gz           # install from URL
+  cpanm https://example.org/LDS/CGI.pm-3.20.tar.gz          # install from URL
   cpanm ~/dists/MyCompany-Enterprise-1.00.tar.gz            # install from a local file
   cpanm --interactive Task::Kensho                          # Configure interactively
   cpanm .                                                   # install from local directory
   cpanm --installdeps .                                     # install all the deps for the current directory
   cpanm -L extlib Plack                                     # install Plack and all non-core deps into extlib
-  cpanm --mirror http://cpan.cpantesters.org/ DBI           # use the fast-syncing mirror
+  cpanm --mirror https://cpan.cpantesters.org/ DBI           # use the fast-syncing mirror
   cpanm -M https://cpan.metacpan.org App::perlbrew          # use only this secure mirror and its index
 
 You can also specify the default options in PERL_CPANM_OPT environment variable in the shell rc:
 
-  export PERL_CPANM_OPT="--prompt --reinstall -l ~/perl --mirror http://cpan.cpantesters.org"
+  export PERL_CPANM_OPT="--prompt --reinstall -l ~/perl --mirror https://cpan.cpantesters.org"
 
 Type `man cpanm` or `perldoc cpanm` for the more detailed explanation of the options.
 
@@ -1163,7 +1163,7 @@ sub chdir {
 sub configure_mirrors {
     my $self = shift;
     unless (@{$self->{mirrors}}) {
-        $self->{mirrors} = [ 'http://www.cpan.org' ];
+        $self->{mirrors} = [ 'https://www.cpan.org' ];
     }
     for (@{$self->{mirrors}}) {
         s!^/!file:///!;
@@ -1688,7 +1688,7 @@ sub cpan_dist {
 sub git_uri {
     my ($self, $uri) = @_;
 
-    # similar to http://www.pip-installer.org/en/latest/logic.html#vcs-support
+    # similar to https://www.pip-installer.org/en/latest/logic.html#vcs-support
     # git URL has to end with .git when you need to use pin @ commit/tag/branch
 
     ($uri, my $commitish) = split /(?<=\.git)@/i, $uri, 2;
@@ -2703,9 +2703,9 @@ sub configure_http {
     unshift @try, 'Curl' if $self->{try_curl};
     unshift @try, 'LWP'  if $self->{try_lwp};
 
-    my @protocol = ('http');
-    push @protocol, 'https'
-      if grep /^https:/, @{$self->{mirrors}};
+    my @protocol = ('https');
+    push @protocol, 'http'
+      if grep /^http:/, @{$self->{mirrors}};
 
     my $backend;
     for my $try (map "HTTP::Tinyish::$_", @try) {

--- a/Menlo/Changes
+++ b/Menlo/Changes
@@ -1,4 +1,4 @@
-See http://github.com/miyagawa/cpanminus/ for the latest development.
+See https://github.com/miyagawa/cpanminus/ for the latest development.
 
 {{$NEXT}}
 

--- a/Menlo/META.json
+++ b/Menlo/META.json
@@ -9,7 +9,7 @@
       "perl_5"
    ],
    "meta-spec" : {
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "url" : "https://search.cpan.org/perldoc?CPAN::Meta::Spec",
       "version" : 2
    },
    "name" : "Menlo",

--- a/Menlo/lib/Menlo/Index/MetaCPAN.pm
+++ b/Menlo/lib/Menlo/Index/MetaCPAN.pm
@@ -55,7 +55,7 @@ sub search_packages {
             package => $args->{package},
             version => $dist_meta->{version},
             uri => "cpan:///distfile/$distfile",
-            download_uri => $self->_download_uri("http://cpan.metacpan.org", $distfile),
+            download_uri => $self->_download_uri("https://cpan.metacpan.org", $distfile),
         };
     }
 

--- a/Menlo/lib/Menlo/Index/MetaDB.pm
+++ b/Menlo/lib/Menlo/Index/MetaDB.pm
@@ -19,7 +19,7 @@ use HTTP::Tiny;
 sub BUILD {
     my $self = shift;
     my $uri  = $self->uri;
-    $uri = "http://cpanmetadb.plackperl.org/v1.0/"
+    $uri = "https://cpanmetadb.plackperl.org/v1.0/"
       unless defined $uri;
     # ensure URI ends in '/'
     $uri =~ s{/?$}{/};
@@ -73,7 +73,7 @@ sub search_packages {
                 version => $match->{version},
                 uri     => "cpan:///distfile/$file",
                 ($match->{latest} ? () :
-                   (download_uri => "http://backpan.perl.org/authors/id/$match->{distfile}")),
+                   (download_uri => "https://backpan.perl.org/authors/id/$match->{distfile}")),
             };
         }
     } else {


### PR DESCRIPTION
Hi Miyagawa! Thank you so much for all the work you put to cpanm, it's an amazing tool that I use pretty much daily.

Right now, cpanm downloads from HTTP, not HTTPS, even on systems with a fully working TLS. 

This patch enforces HTTPS on everything, though still allowing one to force HTTP via `--from` or `--mirror`. 

We have built and tested the fatpacked cpanm with these changes and they all work really well. Please let me know if you have any concerns or if there is anything I can do to get this merged and released.

Cheers!