### PR TITLE
Update CI perl versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         perl-version:
-          - '5.8-buster'
           - '5.10-buster'
           - '5.12-buster'
           - '5.14-buster'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
       run:
         shell: 'script -q -e -c "bash {0}"' # create TTY so that -t STDIN works
     strategy:
+      fail-fast: false
       matrix:
         perl-version:
           - '5.8-buster'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     container:
       image: perl:${{ matrix.perl-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Dependencies
         run: |
           perl App-cpanminus/cpanm -nq App::cpanminus

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,21 @@ jobs:
         perl-version:
           - '5.8-buster'
           - '5.10-buster'
-          - 'latest'
+          - '5.12-buster'
+          - '5.14-buster'
+          - '5.16-buster'
+          - '5.18-buster'
+          - '5.20-buster'
+          - '5.22-buster'
+          - '5.24-buster'
+          - '5.26-buster'
+          - '5.28-buster'
+          - '5.30-buster'
+          - '5.32-buster'
+          - '5.34-buster'
+          - '5.36-buster'
+          - '5.38-buster'
+          - 'devel'
     container:
       image: perl:${{ matrix.perl-version }}
     steps:


### PR DESCRIPTION
remove 5.8 from CI run because a lot of modules can't be installed.