### PR TITLE
When pinning and using MetaDB, install freshest

### DIFF
--- a/Menlo/lib/Menlo/Index/MetaDB.pm
+++ b/Menlo/lib/Menlo/Index/MetaDB.pm
@@ -57,6 +57,7 @@ sub search_packages {
 
         return unless @found;
         $found[-1]->{latest} = 1;
+        @found = reverse @found;
 
         my $match;
         for my $try (sort { $b->{version_o} <=> $a->{version_o} } @found) {


### PR DESCRIPTION
Hi @miyagawa 👋🏼 

Thank you for `cpanminus`

# Without this change
```
$ cpanm --metacpan Acme::Markdown::Embarrassing@3.2 --force
--> Working on Acme::Markdown::Embarrassing
Fetching http://cpan.metacpan.org/authors/id/C/CO/CONTRA/Acme-Markdown-Embarrassing-3.2-again.tar.gz ... OK
...

$ cpanm Acme::Markdown::Embarrassing@3.2 --force
--> Working on Acme::Markdown::Embarrassing
Fetching http://backpan.perl.org/authors/id/C/CO/CONTRA/Acme-Markdown-Embarrassing-3.2.tar.gz ... OK
...
```

Because MetaDB [returns multiple 3.2 versions] of `Acme::Markdown::Embarrassing`: 
```
Acme::Markdown::Embarrassing       0.01  C/CO/CONTRA/Acme-Markdown-Embarrassing-0.01.tar.gz
Acme::Markdown::Embarrassing       0.02  C/CO/CONTRA/Acme-Markdown-Embarrassing-0.02.tar.gz
...
Acme::Markdown::Embarrassing        3.1  C/CO/CONTRA/Acme-Markdown-Embarrassing-3.1.tar.gz
Acme::Markdown::Embarrassing        3.2  C/CO/CONTRA/Acme-Markdown-Embarrassing-3.2.tar.gz
Acme::Markdown::Embarrassing        3.2  C/CO/CONTRA/Acme-Markdown-Embarrassing-3.2-again.tar.gz
``` 